### PR TITLE
Update pact output dir to align with MockServer default

### DIFF
--- a/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
+++ b/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
@@ -79,7 +79,7 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "PACT_DIR"
+            key = "PACT_OUTPUT_DIR"
             value = "$(PROJECT_DIR)/tmp/pacts"
             isEnabled = "YES">
          </EnvironmentVariable>

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -164,7 +164,7 @@ extension MockService {
 	/// - parameter completion: Result of the writing the Pact contract to JSON
 	///
 	/// By default Pact contracts are written to `/tmp/pacts` folder.
-	/// Set `PACT_DIR` to `$(PATH)/to/desired/dir/` in `Build` phase of your `Scheme` to change the location.
+	/// Set `PACT_OUTPUT_DIR` to `$(PATH)/to/desired/dir/` in `Build` phase of your `Scheme` to change the location.
 	func finalize(completion: ((Result<String, MockServerError>) -> Void)? = nil) {
 		pact.interactions = interactions
 		guard let pactData = pact.data, allValidated else {

--- a/Sources/Services/PactFileManager.swift
+++ b/Sources/Services/PactFileManager.swift
@@ -27,7 +27,7 @@ enum PactFileManager {
 	/// (eg: `~/Library/Containers/au.com.pact-foundation.Pact-macOS-Example/Data/Documents`)
 	///
 	/// If testing a sandboxed macOS app, this is the default location and it can not be overwritten.
-	/// If testing a macOS app that is not sandboxed, define a `PACT_DIR` Environment Variable (in the scheme)
+	/// If testing a macOS app that is not sandboxed, define a `PACT_OUTPUT_DIR` Environment Variable (in the scheme)
 	/// with the path to where you want Pact contracts to be written to.
 	///
 	/// ## iOS/tvOS or non-Xcode project
@@ -35,16 +35,16 @@ enum PactFileManager {
 	/// Default location where Pact contracts are written is `/tmp/pacts`.
 	///
 	/// For iOS/tvOS you can override
-	/// that by defining a `PACT_DIR` Environment Variable.
+	/// that by defining a `PACT_OUTPUT_DIR` Environment Variable.
 	static var pactDirectoryPath: String {
 		#if os(macOS) || os(OSX)
 		let defaultPath = NSHomeDirectory() + "/Documents"
 		if isSandboxed {
 			return defaultPath
 		}
-		return ProcessInfo.processInfo.environment["PACT_DIR"] ?? defaultPath
+		return ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? defaultPath
 		#else
-		return ProcessInfo.processInfo.environment["PACT_DIR"] ?? "/tmp/pacts"
+		return ProcessInfo.processInfo.environment["PACT_OUTPUT_DIR"] ?? "/tmp/pacts"
 		#endif
 	}
 


### PR DESCRIPTION
# 📝 Summary of Changes

To align the expectations with MockServer, changing the existing env var for output directory. 

Changes proposed in this pull request:

- Changes `PACT_DIR` to `PACT_OUTPUT_DIR` env var
- Resolves issue #31
