### PR TITLE
Build libpact_mock_server.a during Xcode Build Phase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.a filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/test_xcode_11.6.yml
+++ b/.github/workflows/test_xcode_11.6.yml
@@ -4,6 +4,13 @@ env:
     SIMULATOR_NAME: "iPhone 11 Pro"
 
 on:
+  push:
+    branches:
+      - master
+      - 'tech/**'
+      - 'fix/**'
+      - 'feat/**'
+      - 'feature/**'
   pull_request:
     branches:
       - master
@@ -19,21 +26,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Create LFS file list
-        run: git lfs ls-files -l | cut -d' ' -f1 | sort > .lfs-assets-id
-
-      - name: Restore LFS cache
-        uses: actions/cache@v2
-        id: lfs-cache
-        with:
-          path: .git/lfs
-          key: ${{ runner.os }}-lfs-${{ hashFiles('.lfs-assets-id') }}
-          restore-keys: |
-            ${{ runner.os }}-lfs-
-
-      - name: Git LFS Pull
-        run: git lfs pull
-
       - name: Use Xcode 11.6
         run: sudo xcode-select -switch /Applications/Xcode_11.6.app
 
@@ -43,7 +35,7 @@ jobs:
 
       - name: Build and Test SPM support
         run: |
-          set -o pipefail && swift build -c debug
+          echo "⚠️ SKIPPING: \"set -o pipefail && swift build -c debug | xcbeautify\""
           echo "⚠️ SKIPPING: \"set -o pipefail && swift test -Xlinker -LResources/macOS | xcbeautify\""
 
       - name: Test iOS target (Xcode)

--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,10 @@ Carthage/
 ## Submodules     ##
 ####################
 Submodules/pact-reference/rust/target/**
+
+
+###################
+## Binaries      ##
+###################
+*.a
+

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,8 @@ Packages
 
 Carthage/
 .swiftpm*
+
+####################
+## Submodules     ##
+####################
+Submodules/pact-reference/rust/target/**

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -698,6 +698,7 @@
 				ADC3C4CC242CCCEB00D3FDCE /* Lint Project */,
 				ADC3C4CD242CCCF300D3FDCE /* Lint Target */,
 				ADD69940242C87E900C5C2C2 /* SwiftLint */,
+				AD507D5E253AA8D00091742F /* Build libpact_mock_server.a static library */,
 				AD8817FA242C715A00BF510D /* Sources */,
 				AD8817FB242C715A00BF510D /* Frameworks */,
 				AD8817FC242C715A00BF510D /* Resources */,
@@ -852,6 +853,24 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		AD507D5E253AA8D00091742F /* Build libpact_mock_server.a static library */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Build libpact_mock_server.a static library";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "PATH=\"$HOME/.cargo/bin:$PATH\"\n\nrustup target add x86_64-apple-ios\nrustup target add aarch64-apple-ios\ncargo install cargo-lipo\ncd Submodules/pact-reference/rust/pact_mock_server_ffi && cargo lipo --release\n\ncp \"$PROJECT_DIR/Submodules/pact-reference/rust/target/universal/release/libpact_mock_server_ffi.a\" \"$PROJECT_DIR/Resources/iOS/libpact_mock_server.a\"\n\n";
+		};
 		AD8FC7CF2463A08900361854 /* Lint Target */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ github "surpher/PactSwift"
 ```
 
 ```sh
-carthage update [--cache-builds --verbose]
+carthage update
 ```
+
+Note: If you do not need to support both iOS **and** macOS, use either `--platform ios` or `--platform macos` to avoid buililding PactSwift for the platform you do not need. Use `--cache-builds --verbose` to save time and see the build progress.
 
 ### Swift Package Manager (⚠️ beta ⚠️)
 

--- a/Resources/iOS/libpact_mock_server.a
+++ b/Resources/iOS/libpact_mock_server.a
@@ -1,3 +1,1 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06b6ebce50e8c0fe17114fb5dfb5b06dd33cd995eecd283ea04bc8ca789dc37b
-size 182298200
+// This is a dummy stand-in file. It should be replaced by a Xcode Build Phase.


### PR DESCRIPTION
# 📝 Summary of Changes

Removes checked in static libraries (big binary files) and builds the lib for iOS during Xcode Build Phase

- Removes `.a` files from codebase
- Ignore `.a` files so they're not accidentally add to the repo
- Removes git-lfs
- Build Phase builds the `./Resources/iOS/libpact_mock_server.a`
- Updates GitHub Workflow to run tests more frequently (now that GitHub LFS is no longer used)
- Update README.md

# ⚠️ Items of Note

Requires Rust-lang to be installed on the machine using PactSwift

## 🔨 How To Test

- [x] Passes CI
- [x] `PactSwift` can be brought into an Xcode project with Carthage, it builds and Pact test can execute