### PR TITLE
Support for matchers in request headers, query body and response headers

### DIFF
--- a/PactSwift.xcfilelist
+++ b/PactSwift.xcfilelist
@@ -33,6 +33,7 @@ $(SRCROOT)/Sources/Definitions/MatchingRuleExpressible.swift
 $(SRCROOT)/Sources/Definitions/ErrorReporter.swift
 $(SRCROOT)/Sources/Definitions/MockServerError.swift
 $(SRCROOT)/Sources/Definitions/VerificationError.swift
+$(SRCROOT)/Sources/Definitions/Toolbox.swift
 $(SRCROOT)/Sources/Definitions/RequestError.swift
 $(SRCROOT)/Sources/Definitions/AnyEncodable.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomBool.swift

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -176,6 +176,8 @@
 		ADE9B3C8250A3C4700274672 /* Matcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE9B3C6250A3C4700274672 /* Matcher.swift */; };
 		ADE9B3CA250A435B00274672 /* EqualToTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE9B3C9250A435B00274672 /* EqualToTests.swift */; };
 		ADE9B3CB250A435B00274672 /* EqualToTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE9B3C9250A435B00274672 /* EqualToTests.swift */; };
+		ADEFD134253EEF230081A1B1 /* Toolbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEFD133253EEF230081A1B1 /* Toolbox.swift */; };
+		ADEFD135253EEF230081A1B1 /* Toolbox.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADEFD133253EEF230081A1B1 /* Toolbox.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -320,6 +322,7 @@
 		ADE512F0253533840020EF57 /* libpact_mock_server_ffi.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libpact_mock_server_ffi.dylib; sourceTree = "<group>"; };
 		ADE9B3C6250A3C4700274672 /* Matcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Matcher.swift; sourceTree = "<group>"; };
 		ADE9B3C9250A435B00274672 /* EqualToTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EqualToTests.swift; sourceTree = "<group>"; };
+		ADEFD133253EEF230081A1B1 /* Toolbox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toolbox.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -557,6 +560,7 @@
 				ADDE4705244D11DE00E4F7EE /* ErrorReporter.swift */,
 				AD646FAD2460F76F00979AFC /* MockServer */,
 				AD646FAB2460F75B00979AFC /* Pact */,
+				ADEFD133253EEF230081A1B1 /* Toolbox.swift */,
 			);
 			path = Definitions;
 			sourceTree = "<group>";
@@ -1073,6 +1077,7 @@
 				AD4B970A2513A04800C37560 /* RandomHexadecimal.swift in Sources */,
 				AD7891C224415E3E0014BCC8 /* DecimalLike.swift in Sources */,
 				AD641A422434588200785CE1 /* Interaction.swift in Sources */,
+				ADEFD134253EEF230081A1B1 /* Toolbox.swift in Sources */,
 				AD641A3A24344D9500785CE1 /* Pact.swift in Sources */,
 				ADA40177253028A100265DF3 /* MatchNull.swift in Sources */,
 				AD646FC32460F7CC00979AFC /* MockServer.swift in Sources */,
@@ -1167,6 +1172,7 @@
 				AD4B970B2513A04800C37560 /* RandomHexadecimal.swift in Sources */,
 				AD8FC7E52463BB9F00361854 /* Metadata.swift in Sources */,
 				AD8FC7DB2463BB9A00361854 /* MockServerError.swift in Sources */,
+				ADEFD135253EEF230081A1B1 /* Toolbox.swift in Sources */,
 				AD8FC7FC2463BBC200361854 /* MockServer.swift in Sources */,
 				ADA40178253028A100265DF3 /* MatchNull.swift in Sources */,
 				AD8FC7F82463BBB800361854 /* RegexLike.swift in Sources */,

--- a/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
+++ b/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
@@ -69,11 +69,6 @@
                BlueprintName = "PactSwiftTests_iOS"
                ReferencedContainer = "container:PactSwift.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "MockServiceTests/testMockService_Succeeds_WithMatchersInRequestBody()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Sources/Definitions/Interaction.swift
+++ b/Sources/Definitions/Interaction.swift
@@ -172,7 +172,7 @@ extension Interaction {
 	///   - body: The body of the request
 	@discardableResult
 	@objc(withRequestHTTPMethod: path: query: headers: body:)
-	public func withRequest(method: PactHTTPMethod, path: String, query: [String: [String]]? = nil, headers: [String: String]? = nil, body: Any? = nil) -> Interaction {
+	public func withRequest(method: PactHTTPMethod, path: String, query: [String: [String]]? = nil, headers: [String: Any]? = nil, body: Any? = nil) -> Interaction {
 		self.request = Request(method: method, path: path, query: query, headers: headers, body: body)
 		return self
 	}
@@ -191,7 +191,7 @@ extension Interaction {
 	///   - headers: The response headers
 	///   - body: The response body
 	@discardableResult
-	@objc public func willRespondWith(status: Int, headers: [String: String]? = nil, body: Any? = nil) -> Interaction {
+	@objc public func willRespondWith(status: Int, headers: [String: Any]? = nil, body: Any? = nil) -> Interaction {
 		self.response = Response(statusCode: status, headers: headers, body: body)
 		return self
 	}

--- a/Sources/Definitions/Interaction.swift
+++ b/Sources/Definitions/Interaction.swift
@@ -159,10 +159,22 @@ extension Interaction {
 
 	/// Defines the expected request for the interaction.
 	///
-	///At a minimum the `method` and `path` required to test an API request.
+	/// At a minimum the `method` and `path` required to test an API request.
 	/// By not providing a value for `query`, `headers` or `body` it is
 	/// understood that the presence of those values in the request
 	/// is _not required_ but they can be present.
+	///
+	/// `query` expects a dictionary where the value is an array conforming
+	///  to `String` or a string `Matcher`.
+	///
+	///  ```
+	///  // Verbatim matching for '?states=VIC,NSW,ACT'
+	///  query: ["states": ["ACT", "NSW", "VIC"]]
+	///
+	///  // Matching using a string Matcher for
+	///  query: ["states": [Matcher.SomethingLike("VIC")]] // or
+	///  query: ["states": [Matcher.IncludesLike("VIC")]
+	///  ```
 	///
 	/// - Parameters:
 	///   - method: The HTTP method of the request

--- a/Sources/Definitions/Interaction.swift
+++ b/Sources/Definitions/Interaction.swift
@@ -172,7 +172,7 @@ extension Interaction {
 	///   - body: The body of the request
 	@discardableResult
 	@objc(withRequestHTTPMethod: path: query: headers: body:)
-	public func withRequest(method: PactHTTPMethod, path: String, query: [String: [String]]? = nil, headers: [String: Any]? = nil, body: Any? = nil) -> Interaction {
+	public func withRequest(method: PactHTTPMethod, path: String, query: [String: [Any]]? = nil, headers: [String: Any]? = nil, body: Any? = nil) -> Interaction {
 		self.request = Request(method: method, path: path, query: query, headers: headers, body: body)
 		return self
 	}

--- a/Sources/Definitions/PactBuilder.swift
+++ b/Sources/Definitions/PactBuilder.swift
@@ -40,10 +40,10 @@ struct PactBuilder {
 	/// - parameter interactionNode: The top level node in PACT contract file
 	func encoded(for interactionNode: PactInteractionNode) throws -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?) {
 		do {
-			let processedType = try process(element: typeDefinition, at: "$")
+			let processedType = try process(element: typeDefinition, at: interactionNode == .body ? "$" : "")
 			return (
 				node: processedType.node,
-				rules: processedType.rules.isEmpty ? nil : AnyEncodable([interactionNode.rawValue: AnyEncodable(AnyEncodable(processedType.rules))]),
+				rules: processedType.rules.isEmpty ? nil : AnyEncodable(AnyEncodable(processedType.rules)),
 				generators: processedType.generators.isEmpty ? nil : AnyEncodable([interactionNode.rawValue: AnyEncodable(AnyEncodable(processedType.generators))])
 			)
 		} catch {
@@ -242,7 +242,7 @@ private extension PactBuilder {
 			try dictionary
 				.enumerated()
 				.forEach {
-					let childElement = try process(element: $0.element.value, at: "\(node).\($0.element.key)")
+					let childElement = try process(element: $0.element.value, at: node.isEmpty ? "\($0.element.key)" : "\(node).\($0.element.key)")
 					encodableDictionary[$0.element.key] = childElement.node
 					matchingRules = merge(matchingRules, with: childElement.rules)
 					generators = merge(generators, with: childElement.generators)

--- a/Sources/Definitions/PactBuilder.swift
+++ b/Sources/Definitions/PactBuilder.swift
@@ -20,9 +20,11 @@ import Foundation
 struct PactBuilder {
 
 	let typeDefinition: Any
+	let interactionNode: PactInteractionNode
 
-	init(with value: Any) {
+	init(with value: Any, for interactionNode: PactInteractionNode) {
 		self.typeDefinition = value
+		self.interactionNode = interactionNode
 	}
 
 	/// Returns a tuple of a Pact Contract interaction's node object (eg, request `body`)
@@ -36,9 +38,7 @@ struct PactBuilder {
 	/// - `Double`
 	/// - `Array<Encodable>`
 	/// - `Dictionary<String, Encodable>`
-	///
-	/// - parameter interactionNode: The top level node in PACT contract file
-	func encoded(for interactionNode: PactInteractionNode) throws -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?) {
+	func encoded() throws -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?) {
 		do {
 			let processedType = try process(element: typeDefinition, at: interactionNode == .body ? "$" : "")
 			return (
@@ -221,7 +221,7 @@ private extension PactBuilder {
 			try array
 				.enumerated()
 				.forEach {
-					let childElement = try process(element: $0.element, at: "\(node)[\($0.offset)]")
+					let childElement = try process(element: $0.element, at: interactionNode == .body ? "\(node)[\($0.offset)]" : "\(node)")
 					encodableArray.append(childElement.node)
 					matchingRules = merge(matchingRules, with: childElement.rules)
 					generators = merge(generators, with: childElement.generators)

--- a/Sources/Definitions/PactInteractionElement.swift
+++ b/Sources/Definitions/PactInteractionElement.swift
@@ -20,8 +20,7 @@ import Foundation
 enum PactInteractionNode: String {
 
 	case body
-	case headers
-	case matchingRules
-	case generators
+	case header
+	case query
 
 }

--- a/Sources/Definitions/Request.swift
+++ b/Sources/Definitions/Request.swift
@@ -62,9 +62,9 @@ extension Request: Encodable {
 		self.query = query
 		self.headers = headers
 
-		let queryValues = Request.process(element: query, for: .query)
-		let headersValues = Request.process(element: headers, for: .header)
-		let bodyValues = Request.process(element: body, for: .body)
+		let queryValues = Toolbox.process(element: query, for: .query)
+		let headersValues = Toolbox.process(element: headers, for: .header)
+		let bodyValues = Toolbox.process(element: body, for: .body)
 
 		self.bodyEncoder = {
 			var container = $0.container(keyedBy: CodingKeys.self)
@@ -73,7 +73,7 @@ extension Request: Encodable {
 			if let query = queryValues?.node { try container.encode(query, forKey: .query) }
 			if let headers = headersValues?.node { try container.encode(headers, forKey: .headers) }
 			if let encodableBody = bodyValues?.node { try container.encode(encodableBody, forKey: .body) }
-			if let matchingRules = Request.mergeMatchingRulesFor(query: queryValues?.rules, header: headersValues?.rules, body: bodyValues?.rules) {
+			if let matchingRules = Toolbox.mergeMatchingRulesFor(body: bodyValues?.rules, query: queryValues?.rules, header: headersValues?.rules) {
 				try container.encode(matchingRules, forKey: .matchingRules)
 			}
 			if let generators = bodyValues?.generators { try container.encode(generators, forKey: .generators) }
@@ -82,41 +82,6 @@ extension Request: Encodable {
 
 	public func encode(to encoder: Encoder) throws {
 		try bodyEncoder(encoder)
-	}
-
-}
-
-private extension Request {
-
-	static func mergeMatchingRulesFor(query: AnyEncodable?, header: AnyEncodable?, body: AnyEncodable?) -> AnyEncodable? {
-		var merged: [String: AnyEncodable] = [:]
-
-		if let header = header {
-			merged["header"] = header
-		}
-
-		if let body = body {
-			merged["body"] = body
-		}
-
-		if let query = query {
-			merged["query"] = query
-		}
-
-		return merged.isEmpty ? nil : AnyEncodable(merged)
-	}
-
-	static func process(element: Any?, for interactionElement: PactInteractionNode) -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?)? {
-		if let element = element {
-			do {
-				let encodedElement = try PactBuilder(with: element).encoded(for: interactionElement)
-				return (node: encodedElement.node, rules: encodedElement.rules, generators: encodedElement.generators)
-			} catch {
-				fatalError("Can not process \(interactionElement.rawValue) with non-encodable (non-JSON safe) values")
-			}
-		}
-
-		return nil
 	}
 
 }

--- a/Sources/Definitions/Response.swift
+++ b/Sources/Definitions/Response.swift
@@ -45,12 +45,12 @@ extension Response: Encodable {
 		self.headers = headers
 
 		var bodyValues: (body: AnyEncodable?, matchingRules: AnyEncodable?, generators: AnyEncodable?)
-		var headersValues: (headers: AnyEncodable?, matchingRules: AnyEncodable?, generators: AnyEncodable?)
+		var headerValues: (headers: AnyEncodable?, matchingRules: AnyEncodable?, generators: AnyEncodable?)
 
 		if let headers = headers {
 			do {
-				let parsedHeaders = try PactBuilder(with: headers).encoded(for: .headers)
-				headersValues = (headers: parsedHeaders.node, matchingRules: parsedHeaders.rules, generators: parsedHeaders.generators)
+				let parsedHeaders = try PactBuilder(with: headers).encoded(for: .header)
+				headerValues = (headers: parsedHeaders.node, matchingRules: parsedHeaders.rules, generators: parsedHeaders.generators)
 			} catch {
 				fatalError("Can not process headers with non-encodable (non-JSON safe) values")
 			}
@@ -68,9 +68,9 @@ extension Response: Encodable {
 		self.bodyEncoder = {
 			var container = $0.container(keyedBy: CodingKeys.self)
 			try container.encode(statusCode, forKey: .statusCode)
-			if let headers = headersValues.headers { try container.encode(headers, forKey: .headers) }
+			if let headers = headerValues.headers { try container.encode(headers, forKey: .headers) }
 			if let encodableBody = bodyValues.body { try container.encode(encodableBody, forKey: .body) }
-			if let matchingRules = Request.mergeMatchingRulesFor(headers: headersValues.matchingRules, body: bodyValues.matchingRules) {
+			if let matchingRules = Response.mergeMatchingRulesFor(header: headerValues.matchingRules, body: bodyValues.matchingRules) {
 				try container.encode(matchingRules, forKey: .matchingRules)
 			}
 			if let generators = bodyValues.generators { try container.encode(generators, forKey: .generators) }
@@ -85,11 +85,11 @@ extension Response: Encodable {
 
 extension Response {
 
-	static func mergeMatchingRulesFor(headers: AnyEncodable?, body: AnyEncodable?) -> AnyEncodable? {
+	static func mergeMatchingRulesFor(header: AnyEncodable?, body: AnyEncodable?) -> AnyEncodable? {
 		var merged: [String: AnyEncodable] = [:]
 
-		if let headers = headers {
-			merged["headers"] = headers
+		if let header = header {
+			merged["header"] = header
 		}
 
 		if let body = body {

--- a/Sources/Definitions/Toolbox.swift
+++ b/Sources/Definitions/Toolbox.swift
@@ -1,0 +1,61 @@
+//  Created by Marko Justinek on 20/10/20.
+//  Copyright © 2020 PACT Foundation. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+
+enum Toolbox {
+
+	/// Merges the Pact top level elements into one dictionary thac can be Encoded
+	/// - Parameters:
+	///   - body: The PactBuilder processed object representing interaction's body
+	///   - query: The PactBuilder processed object representing interaction's query
+	///   - header The PactBuilder processed object representing interaction's header
+	static func mergeMatchingRulesFor(body: AnyEncodable?, query: AnyEncodable? = nil, header: AnyEncodable? = nil) -> AnyEncodable? {
+		var merged: [String: AnyEncodable] = [:]
+
+		if let header = header {
+			merged["header"] = header
+		}
+
+		if let body = body {
+			merged["body"] = body
+		}
+
+		if let query = query {
+			merged["query"] = query
+		}
+
+		return merged.isEmpty ? nil : AnyEncodable(merged)
+	}
+
+	/// Runs the `Any` type through PactBuilder and returns a Pact tuple
+	/// - Parameters:
+	///   - element: The object to process through PactBuilder
+	///   - interactionElement: The network interaction element the object relates to
+	static func process(element: Any?, for interactionElement: PactInteractionNode) -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?)? {
+		if let element = element {
+			do {
+				let encodedElement = try PactBuilder(with: element).encoded(for: interactionElement)
+				return (node: encodedElement.node, rules: encodedElement.rules, generators: encodedElement.generators)
+			} catch {
+				fatalError("Can not process \(interactionElement.rawValue) with non-encodable (non-JSON safe) values")
+			}
+		}
+
+		return nil
+	}
+
+}

--- a/Sources/Definitions/Toolbox.swift
+++ b/Sources/Definitions/Toolbox.swift
@@ -48,7 +48,7 @@ enum Toolbox {
 	static func process(element: Any?, for interactionElement: PactInteractionNode) -> (node: AnyEncodable?, rules: AnyEncodable?, generators: AnyEncodable?)? {
 		if let element = element {
 			do {
-				let encodedElement = try PactBuilder(with: element).encoded(for: interactionElement)
+				let encodedElement = try PactBuilder(with: element, for: interactionElement).encoded()
 				return (node: encodedElement.node, rules: encodedElement.rules, generators: encodedElement.generators)
 			} catch {
 				fatalError("Can not process \(interactionElement.rawValue) with non-encodable (non-JSON safe) values")

--- a/Sources/ExampleGenerators/RandomDecimal.swift
+++ b/Sources/ExampleGenerators/RandomDecimal.swift
@@ -29,6 +29,7 @@ public extension ExampleGenerator {
 		///
 		/// - Parameters:
 		///   - digits: Number of digits of the generated `Decimal` value
+		/// - Precondition: `digits` is a positive value
 		public init(digits: Int = 6) {
 			let digits = digits < 9 ? digits : 9
 			self.value = NumberHelper.randomDecimal(digits: digits)
@@ -64,6 +65,7 @@ public class ObjcRandomDecimal: NSObject, ObjcGenerator {
 	///
 	/// - Parameters:
 	///   - digits: Number of digits of the generated `Decimal` value
+	/// - Precondition: `digits` is a positive value
 	@objc(digits:)
 	public init(digits: Int = 6) {
 		type = ExampleGenerator.RandomDecimal(digits: digits)

--- a/Sources/ExampleGenerators/RandomHexadecimal.swift
+++ b/Sources/ExampleGenerators/RandomHexadecimal.swift
@@ -29,6 +29,7 @@ public extension ExampleGenerator {
 		///
 		/// - Parameters:
 		///   - digits: The length of generated hexadecimal string
+		/// - Precondition: `digits` is a positive value
 		public init(digits: UInt8 = 8) {
 			// MockServer overrides this value and returns a new string so accuracy and correctness here is irrelevant
 			self.value = String((0..<digits).map { _ in "0123456789ABCDEF".randomElement()! })
@@ -51,6 +52,7 @@ public class ObjcRandomHexadecimal: NSObject, ObjcGenerator {
 	///
 	/// - Parameters:
 	///   - digits: The length of generated hexadecimal string
+	/// - Precondition: `digits` is a positive value
 	@objc(digits:)
 	public init(digits: Int = 8) {
 		type = ExampleGenerator.RandomHexadecimal(digits: UInt8(digits))

--- a/Sources/ExampleGenerators/RandomInt.swift
+++ b/Sources/ExampleGenerators/RandomInt.swift
@@ -30,6 +30,7 @@ public extension ExampleGenerator {
 		/// - Parameters:
 		///   - min: Minimum possible value
 		///   - max: Maximum possible value
+		/// - Precondition: `min` is a positive value
 		public init(min: Int = 0, max: Int = 2_147_483_647) {
 			self.value = Int.random(in: min...max)
 			self.rules = [
@@ -53,6 +54,7 @@ public class ObjcRandomInt: NSObject, ObjcGenerator {
 	/// - Parameters:
 	///   - min: Minimum possible value
 	///   - max: Maximum possible value
+	/// - Precondition: `min` is a positive value
 	@objc(min: max:)
 	public init(min: Int = 0, max: Int = 2_147_483_647) {
 		type = ExampleGenerator.RandomInt(min: min, max: max)

--- a/Sources/ExampleGenerators/RandomString.swift
+++ b/Sources/ExampleGenerators/RandomString.swift
@@ -33,6 +33,7 @@ public extension ExampleGenerator {
 		///
 		/// - Parameters:
 		///   - size: The size of generated `String`
+		/// - Precondition: `size` is a positive value
 		public init(size: Int = 20) {
 			self.generator = .string
 			self.value = String((0..<size).map { _ in "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".randomElement()! })
@@ -75,6 +76,7 @@ public class OjbcRandomString: NSObject, ObjcGenerator {
 	///
 	/// - Parameters:
 	///   - size: The size of generated `String`
+	/// - Precondition: `size` is a positive value
 	@objc(size:)
 	public init(size: Int = 20) {
 		type = ExampleGenerator.RandomString(size: size)

--- a/Sources/Matchers/EachLike.swift
+++ b/Sources/Matchers/EachLike.swift
@@ -70,6 +70,7 @@ public extension Matcher {
 		///
 		/// - parameter value: Expected type or object
 		/// - parameter min: Minimum expected number of occurances of provided `value`
+		/// - Precondition: `min` must be a positive value
 		public init(_ value: Any, min: Int) {
 			self.value = [value]
 			self.min = min
@@ -82,6 +83,7 @@ public extension Matcher {
 		///
 		/// - parameter value: Expected type or object
 		/// - parameter max: Maximum expected number of occurances of provided `value`
+		/// - Precondition: `min` must be a positive value
 		public init(_ value: Any, max: Int) {
 			self.value = [value]
 			self.min = nil
@@ -95,6 +97,7 @@ public extension Matcher {
 		/// - parameter value: Expected type or object
 		/// - parameter min: Minimum expected number of occurances of provided `value`
 		/// - parameter max: Maximum expected number of occurances of provided `value`
+		/// - Precondition: `min` and `max` must each be a positive value
 		public init(_ value: Any, min: Int, max: Int) {
 			self.value = [value]
 			self.min = min
@@ -123,6 +126,7 @@ public class ObjcEachLike: NSObject, ObjcMatcher {
 	///   - value: Expected type or object
 	///   - min: Minimum expected number of occurances of provided `value`
 	///   - max: Maximum expected number of occurances of provided `value`
+	/// - Precondition: `min` and `max` must each be a positive value
 	@objc(value: min: max:)
 	public init(value: Any, min: Int, max: Int) {
 		type = Matcher.EachLike(value, min: min, max: max)

--- a/Tests/AnyEncodableTests.swift
+++ b/Tests/AnyEncodableTests.swift
@@ -22,50 +22,50 @@ import XCTest
 class AnyEncodableTests: XCTestCase {
 
 	func testEncodableWrapper_Handles_StringValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": "Bar"]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": "Bar"], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":"Bar"}"#)
 	}
 
 	func testEncodableWrapper_Handles_IntegerValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": 123]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": 123], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":123}"#)
 	}
 
 	func testEncodableWrapper_Handles_DoubleValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": Double(123.45)]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": Double(123.45)], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":123.45}"#)
 	}
 
 	func testEncodableWrapper_Handles_DecimalValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": Decimal(string: "123.45")]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": Decimal(string: "123.45")], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":123.45}"#)
 	}
 
 	func testEncodableWrapper_Handles_BoolValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": true]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": true], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":true}"#)
 	}
 
 	func testEncodableWrapper_Handles_ArrayOfStringsValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": ["Bar", "Baz"]]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": ["Bar", "Baz"]], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertEqual(testResult, #"{"Foo":["Bar","Baz"]}"#)
 	}
 
 	func testEncodableWrapper_Handles_ArrayOfDoublesValue() throws {
-		let anyEncodedObject = try PactBuilder(with: ["Foo": [Double(123.45), Double(789.23)]]).encoded(for: .body).node
+		let anyEncodedObject = try PactBuilder(with: ["Foo": [Double(123.45), Double(789.23)]], for: .body).encoded().node
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 		XCTAssertTrue(testResult.contains("789.23")) // NOT THE RIGHT WAY TO TEST THIS! But it will do for now.
 		XCTAssertTrue(testResult.contains(#"{"Foo":[123."#))
 	}
 
 	func testEncodableWrapper_Handles_DictionaryValue() throws {
-		let anyEncodedObject =  try PactBuilder(with: ["Foo": ["Bar": "Baz"]]).encoded(for: .body).node
+		let anyEncodedObject =  try PactBuilder(with: ["Foo": ["Bar": "Baz"]], for: .body).encoded().node
 		let testResult = try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!"))
 		XCTAssertEqual(String(data: testResult, encoding: .utf8), #"{"Foo":{"Bar":"Baz"}}"#)
 	}
@@ -80,8 +80,9 @@ class AnyEncodableTests: XCTestCase {
 					"one": [1, 23.45],
 					"two": true
 				]
-			]
-		).encoded(for: .body).node
+			],
+			for: .body
+		).encoded().node
 
 		let testResult = try XCTUnwrap(String(data: try JSONEncoder().encode(try XCTUnwrap(anyEncodedObject, "Oh noez!")), encoding: .utf8))
 
@@ -103,7 +104,7 @@ class AnyEncodableTests: XCTestCase {
 		}
 
 		do {
-			_ = try PactBuilder(with: FailingTestModel()).encoded(for: .body).node
+			_ = try PactBuilder(with: FailingTestModel(), for: .body).encoded().node
 			XCTFail("Expected the EncodableWrapper to throw!")
 		} catch {
 			do {
@@ -130,7 +131,7 @@ class AnyEncodableTests: XCTestCase {
 		let testableObject = FailingTestModel(array: [testDate])
 
 		do {
-			_ = try PactBuilder(with: testableObject.failingArray).encoded(for: .body).node
+			_ = try PactBuilder(with: testableObject.failingArray, for: .body).encoded().node
 			XCTFail("Expected the EncodableWrapper to throw!")
 		} catch {
 			do {
@@ -150,7 +151,7 @@ class AnyEncodableTests: XCTestCase {
 		let testableObject = FailingTestModel()
 
 		do {
-			_ = try PactBuilder(with: testableObject.failingDict).encoded(for: .body).node
+			_ = try PactBuilder(with: testableObject.failingDict, for: .body).encoded().node
 			XCTFail("Expected the EncodableWrapper to throw!")
 		} catch {
 			do {

--- a/Tests/Definitions/PactBuilderTests.swift
+++ b/Tests/Definitions/PactBuilderTests.swift
@@ -339,7 +339,7 @@ class PactBuilderTests: XCTestCase {
 		let testPact = prepareTestPact(requestBody: testBody, requestHeaders: testHeaders)
 		let testResult = try XCTUnwrap(try JSONDecoder().decode(SomethingLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules)
 
-		XCTAssertEqual(testResult.headers?.foo.matchers.first?.match, "type")
+		XCTAssertEqual(testResult.header?.foo.matchers.first?.match, "type")
 		XCTAssertEqual(testResult.body?.foo?.matchers.first?.match, "type")
 	}
 
@@ -454,7 +454,7 @@ private extension PactBuilderTests {
 				let matchingRules: TestMatchingRulesModel
 				struct TestMatchingRulesModel: Decodable {
 					let body: TestBodyModel?
-					let headers: TestHeadersModel?
+					let header: TestHeadersModel?
 					struct TestBodyModel: Decodable {
 						let foo: TestMatchersModel?
 						let bar: TestMatchersModel?

--- a/Tests/Definitions/PactBuilderTests.swift
+++ b/Tests/Definitions/PactBuilderTests.swift
@@ -28,8 +28,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.EqualTo("2016-07-19")
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.match, "equality")
 	}
@@ -41,8 +41,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.SomethingLike("2016-07-19")
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.match, "type")
 	}
@@ -62,8 +62,8 @@ class PactBuilderTests: XCTestCase {
 			]
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.min, 1)
 		XCTAssertEqual(testResult.match, "type")
@@ -83,8 +83,8 @@ class PactBuilderTests: XCTestCase {
 			]
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.min, 3)
 		XCTAssertEqual(testResult.match, "type")
@@ -104,8 +104,8 @@ class PactBuilderTests: XCTestCase {
 			]
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.max, 5)
 		XCTAssertEqual(testResult.match, "type")
@@ -126,8 +126,8 @@ class PactBuilderTests: XCTestCase {
 			]
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(SetLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.min, 1)
 		XCTAssertEqual(testResult.max, 5)
@@ -141,8 +141,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.IntegerLike(1234)
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.match, "integer")
 	}
@@ -154,8 +154,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.DecimalLike(1234)
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node.matchers.first)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node.matchers.first)
 
 		XCTAssertEqual(testResult.match, "decimal")
 	}
@@ -167,8 +167,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.RegexLike("2020-12-31", term: "\\d{4}-\\d{2}-\\d{2}")
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let matchers = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let matchers = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node)
 
 		XCTAssertEqual(matchers.matchers.first?.match, "regex")
 		XCTAssertEqual(matchers.matchers.first?.regex, "\\d{4}-\\d{2}-\\d{2}")
@@ -183,8 +183,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.IncludesLike("2020-12-31", "2019-12-31")
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node)
 
 		XCTAssertEqual(testResult.combine, "AND")
 		XCTAssertEqual(testResult.matchers.count, 2)
@@ -198,8 +198,8 @@ class PactBuilderTests: XCTestCase {
 			"data": Matcher.IncludesLike("2020-12-31", "2019-12-31", combine: .OR)
 		]
 
-		let testPact = prepareTestPact(for: testBody)
-		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericLikeTestModel.self, from: testPact.data!).interactions.first?.response.matchingRules.body.node)
 
 		XCTAssertEqual(testResult.combine, "OR")
 		XCTAssertEqual(testResult.matchers.count, 2)
@@ -207,124 +207,141 @@ class PactBuilderTests: XCTestCase {
 		XCTAssertTrue(testResult.matchers.allSatisfy { $0.match == "include" })
 	}
 
-		// MARK: - Example generators
+	// MARK: - Example generators
 
-		func testPact_SetsExampleGenerator_RandomBool() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomBool()
-			]
+	func testPact_SetsExampleGenerator_RandomBool() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomBool()
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "RandomBoolean")
-		}
+		XCTAssertEqual(testResult.type, "RandomBoolean")
+	}
 
-		func testPact_SetsExampleGenerator_RandomDate() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomDate(format: "dd-MM-yyyy")
-			]
+	func testPact_SetsExampleGenerator_RandomDate() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomDate(format: "dd-MM-yyyy")
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "Date")
-			XCTAssertEqual(testResult.format, "dd-MM-yyyy")
-		}
+		XCTAssertEqual(testResult.type, "Date")
+		XCTAssertEqual(testResult.format, "dd-MM-yyyy")
+	}
 
-		func testPact_SetsExampleGenerator_RandomDateTime() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomDate(format: "dd-MM-yyyy"),
-				"foo": ExampleGenerator.RandomDateTime(format: "HH:mm (dd/MM)")
-			]
+	func testPact_SetsExampleGenerator_RandomDateTime() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomDate(format: "dd-MM-yyyy"),
+			"foo": ExampleGenerator.RandomDateTime(format: "HH:mm (dd/MM)")
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body)
 
-			XCTAssertEqual(testResult.node.type, "Date")
-			XCTAssertEqual(testResult.node.format, "dd-MM-yyyy")
+		XCTAssertEqual(testResult.node.type, "Date")
+		XCTAssertEqual(testResult.node.format, "dd-MM-yyyy")
 
-			XCTAssertEqual(testResult.foo?.type, "DateTime")
-			XCTAssertEqual(testResult.foo?.format, "HH:mm (dd/MM)")
-		}
+		XCTAssertEqual(testResult.foo?.type, "DateTime")
+		XCTAssertEqual(testResult.foo?.format, "HH:mm (dd/MM)")
+	}
 
-		func testPact_SetsExampleGenerator_RandomDecimal() throws {
-			let testBody: Any = [
-					"data": ExampleGenerator.RandomDecimal(digits: 5)
-			]
+	func testPact_SetsExampleGenerator_RandomDecimal() throws {
+		let testBody: Any = [
+				"data": ExampleGenerator.RandomDecimal(digits: 5)
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "RandomDecimal")
-			XCTAssertEqual(testResult.digits, 5)
-		}
+		XCTAssertEqual(testResult.type, "RandomDecimal")
+		XCTAssertEqual(testResult.digits, 5)
+	}
 
-		func testPact_SetsExampleGenerator_RandomHexadecimal() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomHexadecimal(digits: 16)
-			]
+	func testPact_SetsExampleGenerator_RandomHexadecimal() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomHexadecimal(digits: 16)
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "RandomHexadecimal")
-			XCTAssertEqual(testResult.digits, 16)
-		}
+		XCTAssertEqual(testResult.type, "RandomHexadecimal")
+		XCTAssertEqual(testResult.digits, 16)
+	}
 
-		func testPact_SetsExampleGenerator_RandomInt() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomInt(min: 2, max: 16)
-			]
+	func testPact_SetsExampleGenerator_RandomInt() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomInt(min: 2, max: 16)
+		]
 
-			let testPact = prepareTestPact(for: testBody)
+		let testPact = prepareTestPact(responseBody: testBody)
 
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "RandomInt")
-			XCTAssertEqual(testResult.min, 2)
-			XCTAssertEqual(testResult.max, 16)
-		}
+		XCTAssertEqual(testResult.type, "RandomInt")
+		XCTAssertEqual(testResult.min, 2)
+		XCTAssertEqual(testResult.max, 16)
+	}
 
-		func testPact_SetsExampleGenerator_RandomString() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomString(size: 32),
-				"foo": ExampleGenerator.RandomString(regex: #"\d{3}"#)
-			]
+	func testPact_SetsExampleGenerator_RandomString() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomString(size: 32),
+			"foo": ExampleGenerator.RandomString(regex: #"\d{3}"#)
+		]
 
-			let testPact = prepareTestPact(for: testBody)
+		let testPact = prepareTestPact(responseBody: testBody)
 
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body)
 
-			XCTAssertEqual(testResult.node.type, "RandomString")
-			XCTAssertEqual(testResult.node.size, 32)
+		XCTAssertEqual(testResult.node.type, "RandomString")
+		XCTAssertEqual(testResult.node.size, 32)
 
-			XCTAssertEqual(testResult.foo?.type, "Regex")
-			XCTAssertEqual(testResult.foo?.regex, "\\d{3}")
-		}
+		XCTAssertEqual(testResult.foo?.type, "Regex")
+		XCTAssertEqual(testResult.foo?.regex, "\\d{3}")
+	}
 
-		func testPact_SetsExampleGenerator_RandomTime() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomTime(format: "hh - mm")
-			]
+	func testPact_SetsExampleGenerator_RandomTime() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomTime(format: "hh - mm")
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "Time")
-			XCTAssertEqual(testResult.format, "hh - mm")
-		}
+		XCTAssertEqual(testResult.type, "Time")
+		XCTAssertEqual(testResult.format, "hh - mm")
+	}
 
-		func testPact_SetsExampleGenerator_RandomUUID() throws {
-			let testBody: Any = [
-				"data": ExampleGenerator.RandomUUID()
-			]
+	func testPact_SetsExampleGenerator_RandomUUID() throws {
+		let testBody: Any = [
+			"data": ExampleGenerator.RandomUUID()
+		]
 
-			let testPact = prepareTestPact(for: testBody)
-			let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.request.generators.body.node)
+		let testPact = prepareTestPact(responseBody: testBody)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(GenericExampleGeneratorTestModel.self, from: testPact.data!).interactions.first?.response.generators.body.node)
 
-			XCTAssertEqual(testResult.type, "Uuid")
-		}
+		XCTAssertEqual(testResult.type, "Uuid")
+	}
+
+	// MARK: - Testing parsing for headers
+
+	func testPact_ProcessesMatchers_InHeaders() throws {
+		let testHeaders: Any = [
+			"foo": Matcher.SomethingLike("bar")
+		]
+		let testBody: Any = [
+			"foo": Matcher.SomethingLike("baz")
+		]
+
+		let testPact = prepareTestPact(requestBody: testBody, requestHeaders: testHeaders)
+		let testResult = try XCTUnwrap(try JSONDecoder().decode(SomethingLikeTestModel.self, from: testPact.data!).interactions.first?.request.matchingRules)
+
+		XCTAssertEqual(testResult.headers?.foo.matchers.first?.match, "type")
+		XCTAssertEqual(testResult.body?.foo?.matchers.first?.match, "type")
+	}
 
 }
 
@@ -336,8 +353,8 @@ private extension PactBuilderTests {
 	struct GenericLikeTestModel: Decodable {
 		let interactions: [TestInteractionModel]
 		struct TestInteractionModel: Decodable {
-			let request: TestRequestModel
-			struct TestRequestModel: Decodable {
+			let response: TestResponseModel
+			struct TestResponseModel: Decodable {
 				let matchingRules: TestMatchingRulesModel
 				struct TestMatchingRulesModel: Decodable {
 					let body: TestNodeModel
@@ -371,8 +388,8 @@ private extension PactBuilderTests {
 		struct GenericExampleGeneratorTestModel: Decodable {
 			let interactions: [TestInteractionModel]
 			struct TestInteractionModel: Decodable {
-				let request: TestRequestModel
-				struct TestRequestModel: Decodable {
+				let response: TestResponseModel
+				struct TestResponseModel: Decodable {
 					let generators: TestGeneratorModel
 					struct TestGeneratorModel: Decodable {
 						let body: TestNodeModel
@@ -404,7 +421,7 @@ private extension PactBuilderTests {
 	struct SetLikeTestModel: Decodable {
 		let interactions: [TestInteractionModel]
 		struct TestInteractionModel: Decodable {
-			let request: TestRequestModel
+			let response: TestRequestModel
 			struct TestRequestModel: Decodable {
 				let matchingRules: TestMatchingRulesModel
 				struct TestMatchingRulesModel: Decodable {
@@ -428,16 +445,87 @@ private extension PactBuilderTests {
 		}
 	}
 
-	func prepareTestPact(for body: Any) -> Pact {
+	// This test model is tightly coupled with the Pact that includes matchers in request body
+	struct SomethingLikeTestModel: Decodable {
+		let interactions: [TestInteractionModel]
+		struct TestInteractionModel: Decodable {
+			let request: TestResponseModel
+			struct TestResponseModel: Decodable {
+				let matchingRules: TestMatchingRulesModel
+				struct TestMatchingRulesModel: Decodable {
+					let body: TestBodyModel?
+					let headers: TestHeadersModel?
+					struct TestBodyModel: Decodable {
+						let foo: TestMatchersModel?
+						let bar: TestMatchersModel?
+						enum CodingKeys: String, CodingKey {
+							case foo = "$.foo"
+							case bar = "$.bar"
+						}
+						struct TestMatchersModel: Decodable {
+							let matchers: [TestTypeModel]
+							let combine: String?
+							struct TestTypeModel: Decodable {
+								let match: String
+								let regex: String?
+								let value: String?
+								let min: Int?
+								let max: Int?
+							}
+						}
+					}
+					struct TestHeadersModel: Decodable {
+						let foo: TestMatchersModel
+						let bar: TestMatchersModel?
+						struct TestMatchersModel: Decodable {
+							let matchers: [TestTypeModel]
+							let combine: String?
+							struct TestTypeModel: Decodable {
+								let match: String
+								let regex: String?
+								let value: String?
+								let min: Int?
+								let max: Int?
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	func prepareTestPact(responseBody: Any) -> Pact {
 		let firstProviderState = ProviderState(description: "an alligator with the given name exists", params: ["name": "Mary"])
+
+		let interaction = Interaction(description: "test Encodable Pact", providerStates: [firstProviderState])
+			.withRequest(method: .GET, path: "/")
+			.willRespondWith(
+				status: 200,
+				headers: ["Content-Type": "applicatoin/json; charset=UTF-8", "X-Value": "testCode"],
+				body: responseBody
+			)
+
+		return Pact(
+			consumer: Pacticipant.consumer("test-consumer"),
+			provider: Pacticipant.provider("test-provider"),
+			interactions: [interaction]
+		)
+	}
+
+	func prepareTestPact(requestBody: Any, requestHeaders: Any?) -> Pact {
+		let firstProviderState = ProviderState(description: "an alligator with the given name exists", params: ["name": "Mary"])
+
+		let headers: [String: Any]? = requestHeaders != nil ? (requestHeaders as! [String : Any]) : nil
 
 		let interaction = Interaction(description: "test Encodable Pact", providerStates: [firstProviderState])
 			.withRequest(
 				method: .GET,
 				path: "/",
-				query: ["max_results": ["100"]],
-				headers: ["Content-Type": "applicatoin/json; charset=UTF-8", "X-Value": "testCode"],
-				body: body
+				headers: headers,
+				body: requestBody
+			)
+			.willRespondWith(
+				status: 200
 			)
 
 		return Pact(
@@ -448,5 +536,3 @@ private extension PactBuilderTests {
 	}
 
 }
-
-

--- a/Tests/Definitions/PactTests.swift
+++ b/Tests/Definitions/PactTests.swift
@@ -100,7 +100,7 @@ class PactTests: XCTestCase {
 
 		let testPact = prepareTestPact(interactions: interaction)
 
-		let testResult = try XCTUnwrap(((testPact.payload["interactions"] as? [Interaction])?.first?.request?.headers))
+		let testResult = try XCTUnwrap(((testPact.payload["interactions"] as? [Interaction])?.first?.request?.headers) as? [String: String])
 		XCTAssertEqual(testResult["Content-Type"], expectedResult["Content-Type"])
 		XCTAssertEqual(testResult["X-Value"], expectedResult["X-Value"])
 	}

--- a/Tests/Definitions/PactTests.swift
+++ b/Tests/Definitions/PactTests.swift
@@ -132,9 +132,9 @@ class PactTests: XCTestCase {
 		let testPact = prepareTestPact(interactions: interaction)
 
 		let testResult = try XCTUnwrap(((testPact.payload["interactions"] as? [Interaction])?.first?.request?.query))
-		XCTAssertTrue(try (XCTUnwrap(testResult["max_results"]).contains("100")))
-		XCTAssertTrue(try (XCTUnwrap(testResult["state"]).contains("NSW")))
-		XCTAssertTrue(try (XCTUnwrap(testResult["term"]).contains("80 CLARENCE ST, SYDNEY NSW 2000")))
+		XCTAssertTrue(try (XCTUnwrap(testResult["max_results"]).contains { $0 as! String == "100" }))
+		XCTAssertTrue(try (XCTUnwrap(testResult["state"]).contains { $0 as! String == "NSW" }))
+		XCTAssertTrue(try (XCTUnwrap(testResult["term"]).contains { $0 as! String == "80 CLARENCE ST, SYDNEY NSW 2000" }))
 	}
 
 	func testPact_SetsProviderState() throws {

--- a/Tests/MockServiceTests.swift
+++ b/Tests/MockServiceTests.swift
@@ -434,10 +434,10 @@ class MockServiceTests: XCTestCase {
 			.withRequest(
 				method: .PUT,
 				path: "/user/update",
-				headers: ["Content-Type": "application/json"],
+				headers: ["Content-Type": Matcher.EqualTo("application/json")],
 				body: [
 					"name": Matcher.SomethingLike("Joe"),
-					"age": Matcher.IntegerLike(42)
+					"age": Matcher.SomethingLike(42)
 				]
 			)
 			.willRespondWith(


### PR DESCRIPTION
# 📝 Summary of Changes

Changes to `PactBuilder` which allow for parsing the interaction elements for Encodable values and Matchers. This allows for better and more flexible Pact tests and contracts.

Changes proposed in this pull request:

- Resolves issue #46 by refactoring and updating `PactBuilder.swift`
- Adds more unit tests
- Changes the `PactBuilder.init()` and `.process()` method signatures
- Extracts methods used by `Request` and `Reponse` types into a `Toolbox` enum static methods

# ⚠️ Items of Note

- There's more and more benefit in getting some tests up that would read the generated file and test the values written are the ones expected (#35).

# 🧐🗒 Reviewer Notes


## 💁 Example

### Within PactSwift
Instead of:
`PactBuilder(element: ["foo": Matcher.SomethingLike("bar")]).encoded(for: .body)`

Will now be:
`PactBuilder(element: ["foo": Matcher.SomethingLike("bar")], for: .body).encoded()`

### On Caller side

Requests and responses can now use Matchers in any interaction element apart from `description`, `statusCode` and `path`:

```swift
.withRequest(
    method: .GET,
    path: "/movies",
    query: [
        "page": [Matcher.SomethingLike("1")],
        "items": [Matcher.SomethingLike("25")],
    ],
    headers: [
        "Authorization": Matcher.RegexLike("Bearer abcd12345", term: #"^Bearer \w+$"#)
    ],
    body: [
        "values": Matcher.EachLike(1),
    ]
)
.willRespondWith(
    status: 200, 
    headers: [
        "Set-Cookie": Matcher.RegexLike(#"\w+"#),
    ],
     body: [
         "foo": Matcher.SomethingLike("bar"),
         "baz": Matcher.EachLike(1),
    ]
)
```

## 🔨 How To Test

- [x] CI passes
- [x] Example projects build and run the pact tests having PactSwift pulled in as a Carthage dependency

_Provide instructions on how to test your changes._