### PR TITLE
Add port configuration for MockService and MockServer

### DIFF
--- a/Sources/Services/MockServer.swift
+++ b/Sources/Services/MockServer.swift
@@ -39,8 +39,12 @@ class MockServer {
 
 	// MARK: - Lifecycle
 
-	init(port: Int32? = nil) {
-		self.port = port ?? PactSocketFinder.unusedPort()
+	init(port: Int? = nil) {
+		if let port = port {
+			self.port = Int32(port)
+		} else {
+			self.port = PactSocketFinder.unusedPort()
+		}
 	}
 
 	deinit {

--- a/Sources/Services/MockServer.swift
+++ b/Sources/Services/MockServer.swift
@@ -30,17 +30,18 @@ class MockServer {
 		"\(transferProtocol.protocol)://\(socketAddress):\(port)"
 	}
 
-	lazy private var port: Int32 = {
-		PactSocketFinder.unusedPort()
-	}()
-
 	private let socketAddress = "0.0.0.0"
+	private let port: Int32
 	private var transferProtocol: MockService.TransferProtocol = .standard
 	private var tls: Bool {
 		transferProtocol == .secure ? true : false
 	}
 
 	// MARK: - Lifecycle
+
+	init(port: Int32? = nil) {
+		self.port = port ?? PactSocketFinder.unusedPort()
+	}
 
 	deinit {
 		shutdownMockServer()
@@ -53,15 +54,15 @@ class MockServer {
 		Logger.log(message: "Setting up libpact_mock_server", data: pact)
 		transferProtocol = `protocol`
 		Logger.log(message: "Setting up MockServer for Pact interaction test")
-		port = create_mock_server(
+		let mockServerPort = create_mock_server(
 			String(data: pact, encoding: .utf8),
 			"\(socketAddress):\(port)",
 			tls
 		)
 
-		return (port > 1_200)
-			? completion(Result.success(Int(port)))
-			: completion(Result.failure(MockServerError(code: Int(port))))
+		return (mockServerPort > 1_200)
+			? completion(Result.success(Int(mockServerPort)))
+			: completion(Result.failure(MockServerError(code: Int(mockServerPort))))
 	}
 
 	/// Verify interactions

--- a/Sources/Services/MockService.swift
+++ b/Sources/Services/MockService.swift
@@ -93,11 +93,7 @@ let kTimeout: TimeInterval = 10
 	///   - errorReporter: Injectable object to intercept errors
 	internal init(consumer: String, provider: String, scheme: TransferProtocol = .standard, port: Int? = nil, errorReporter: ErrorReportable? = nil) {
 		pact = Pact(consumer: Pacticipant.consumer(consumer), provider: Pacticipant.provider(provider))
-		if let port = port {
-			mockServer = MockServer(port: Int32(port))
-		} else {
-			mockServer = MockServer()
-		}
+		mockServer = MockServer(port: port)
 		self.errorReporter = errorReporter ?? ErrorReporter()
 		self.transferProtocolScheme = scheme
 	}

--- a/Sources/Services/MockService.swift
+++ b/Sources/Services/MockService.swift
@@ -68,16 +68,36 @@ let kTimeout: TimeInterval = 10
 	/// Initializes a `MockService` object that handles Pact interaction testing.
 	///
 	/// When initializing with `.secure` scheme, the SSL certificate on Mock Server
+	/// is a self-signed certificate
+	///
+	/// - Parameters:
+	///   - consumer: Name of the API consumer (eg: "mobile-app")
+	///   - provider: Name of the API provider (eg: "auth-service")
+	///   - scheme: HTTP scheme
+	///   - port: The port number to run the MockServer on (greater than 1200)
+	@objc(initWithConsumer: provider: transferProtocol: port:)
+	public convenience init(consumer: String, provider: String, scheme: TransferProtocol = .standard, port: Int) {
+		self.init(consumer: consumer, provider: provider, scheme: scheme, port: port, errorReporter: ErrorReporter())
+	}
+
+	/// Initializes a `MockService` object that handles Pact interaction testing.
+	///
+	/// When initializing with `.secure` scheme, the SSL certificate on Mock Server
 	/// is a self-signed certificate.
 	///
 	/// - Parameters:
 	///   - consumer: Name of the API consumer (eg: "mobile-app")
 	///   - provider: Name of the API provider (eg: "auth-service")
 	///   - scheme: HTTP scheme
+	///   - port: The port number to run the MockServer on
 	///   - errorReporter: Injectable object to intercept errors
-	internal init(consumer: String, provider: String, scheme: TransferProtocol = .standard, errorReporter: ErrorReportable? = nil) {
+	internal init(consumer: String, provider: String, scheme: TransferProtocol = .standard, port: Int? = nil, errorReporter: ErrorReportable? = nil) {
 		pact = Pact(consumer: Pacticipant.consumer(consumer), provider: Pacticipant.provider(provider))
-		mockServer = MockServer()
+		if let port = port {
+			mockServer = MockServer(port: Int32(port))
+		} else {
+			mockServer = MockServer()
+		}
 		self.errorReporter = errorReporter ?? ErrorReporter()
 		self.transferProtocolScheme = scheme
 	}

--- a/Tests/Services/MockServerTests.swift
+++ b/Tests/Services/MockServerTests.swift
@@ -47,6 +47,11 @@ class MockServerTests: XCTestCase {
 		}
 	}
 
+	func testMockServer_InitializesWithPort() {
+		let mockServer = MockServer(port: 1235)
+		XCTAssertEqual(mockServer.baseUrl, "http://0.0.0.0:1235")
+	}
+
 	func testMockServer_SetsBaseURL_WithPort() {
 		mockServer.setup(pact: "{\"foo\":\"bar\"}".data(using: .utf8)!) {
 			switch $0 {


### PR DESCRIPTION
# 📝 Summary of Changes

The changes in this PR introduce a new `MockService` initializer that accepts the `port` number on which to run the `MockServer`. This will allow tests to always run on the same port between test runs.

Along with the PactSwift enhancements described above, the following has been done:
- Improves `MockService` tests
- Update SwiftLint Phase Script for `v0.41.0`
- Update GitHub Actions workflows

# ⚠️ Items of Note

- **ISSUE: aarch64** - Xcode 12.2 requires binaries to contain `aarch64` slices. ~This means that the script that builds `pact_mock_server.a` needs to build for `aarch64` and `x86_64` and create a fat binary containing both slices. Though the `cargo build` fails when even when using Rust nightly toolchain. It fails when building the `pact_mock_server.a` binary for `aarch64` architecture from Rust code (building on `x86_64` machines) due to `pact_mock_server`'s dependencies' fail to build. Please focus on `iOS` platform when using Carthage or preferrably use Swift Package Manager to bring `PactSwift` into your project.~ `arm64` architecture for macOS has been removed with #53 until better support is available.
- Port remains random if not provided when initialising `MockService`
- Only port numbers above `1200` are valid and if port is not available it should fail with `MockServerError(code:)`

# 🧐🗒 Reviewer Notes

- Resolves #50 

## 🔨 How To Test

- [x] CI passes
- [ ] Setup a test signing the URL with HMAC (optional)