### PR TITLE
Exclude arm64 for macos

### DIFF
--- a/.github/workflows/test_SPM_xcode_12.yml
+++ b/.github/workflows/test_SPM_xcode_12.yml
@@ -7,7 +7,6 @@ env:
 on:
   push:
     branches:
-      - master
       - 'tech/**'
       - 'fix/**'
       - 'feat/**'
@@ -40,7 +39,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Use Xcode 12
-        run: sudo xcode-select -switch /Applications/Xcode_12.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
 
       - name: Prepare Tools
         run: |

--- a/.github/workflows/test_xcode_11.6.yml
+++ b/.github/workflows/test_xcode_11.6.yml
@@ -6,7 +6,6 @@ env:
 on:
   push:
     branches:
-      - master
       - 'tech/**'
       - 'fix/**'
       - 'feat/**'

--- a/.github/workflows/test_xcode_12.yml
+++ b/.github/workflows/test_xcode_12.yml
@@ -3,7 +3,6 @@ name: Run tests (12)
 on:
   push:
     branches:
-      - master
       - 'tech/**'
       - 'fix/**'
       - 'feat/**'
@@ -36,7 +35,7 @@ jobs:
             ${{ runner.os }}-
 
       - name: Use Xcode 12.2
-        run: sudo xcode-select -switch /Applications/Xcode_12.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
 
       - name: Prepare Tools
         run: |
@@ -44,7 +43,7 @@ jobs:
 
       - name: Test iOS target (Xcode)
         run: |
-          set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-iOS -destination "platform=iOS Simulator,name=iPhone 11 Pro" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcbeautify
+          set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-iOS -destination "platform=iOS Simulator,name=iPhone 12 Pro" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcbeautify
 
       - name: Test macOS target (Xcode)
         run: |

--- a/Configurations/Target-macOS-Shared.xcconfig
+++ b/Configurations/Target-macOS-Shared.xcconfig
@@ -1,5 +1,9 @@
 PRODUCT_NAME = PactSwift
 
+// TODO: Once `libpact_mock_server` contains both slices for `arch64` and `x86_64` the following should be removed
+ONLY_ACTIVE_ARCH = YES
+EXCLUDED_ARCHS = arm64 arm64e
+
 SDKROOT = macosx
 MACOSX_DEPLOYMENT_TARGET = 10.12
 CODE_SIGN_STYLE = Automatic

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -928,7 +928,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Run SwiftLint before even attempting to compil\n./Scripts/build_file_list_and_swiftlint PactSwift ../.swiftlint.yml\n";
+			shellScript = "# Run SwiftLint before even attempting to compil\n./Scripts/build_file_list_and_swiftlint PactSwift .swiftlint.yml\n";
 		};
 		ADC3C4CC242CCCEB00D3FDCE /* Lint Project */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1002,7 +1002,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Run SwiftLint before even attempting to compil\n./Scripts/build_file_list_and_swiftlint PactSwift ../.swiftlint.yml\n";
+			shellScript = "# Run SwiftLint before even attempting to compil\n./Scripts/build_file_list_and_swiftlint PactSwift .swiftlint.yml\n";
 		};
 		ADE512E625352C370020EF57 /* Build libpact_mock_server.a static library  - `cargo build --release` */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/README.md
+++ b/README.md
@@ -14,13 +14,17 @@
   <img src="Documentation/images/pact-swift.png" width="350" alt="PactSwift logo" />
 </p>
 
-> ⚠️ **NOTE** ⚠️  
-> `PactSwift` is under heavy development.
-> Any and all help with testing, raising issues and suggestions for improvement is more than welcome.
-
 This framework provides a Swift DSL for generating [Pact][pact-docs] contracts.
 
-It implements [Pact Specification v3][pact-specification-v3] and takes advantage of [`libpact_mock_server`][pact-reference-rust] running it "in process". 
+It implements [Pact Specification v3][pact-specification-v3] and takes advantage of [`libpact_mock_server`][pact-reference-rust] running it "in process".
+
+> ⚠️ **NOTE** ⚠️  
+> `PactSwift` is under heavy development. We are specifically looking into supporting for `arm64`, `arm64e` along with `x86_64`.  
+> Any and all help with testing, raising issues and suggestions for improvement is more than welcome.
+
+> 🚨 **IMPORTANT** 🚨  
+> Due to the new Apple Silicon architecture and required tools' limited support for `arm64` and `arm64e` architecture, `PactSwift` only works for macOS `x86_64` architecture **for now**!   
+> Any and all help finding a working solution is more than welcome. See [#52][github-issues-52].
 
 ## Requirements
 
@@ -289,6 +293,7 @@ Logo and branding images provided by [@cjmlgrto](https://github.com/cjmlgrto).
 [github-action-xcode11.6]: https://github.com/surpher/PactSwift/actions?query=workflow%3A%22Run+tests+%2811.6%29%22
 [github-action-xcode12]: https://github.com/surpher/PactSwift/actions?query=workflow%3A%22Run+tests+%2812%29%22
 [github-action-xcode-spm]: https://github.com/surpher/PactSwift/actions?query=workflow%3A%22Run+tests+for+SPM+%28Xcode+12%29%22
+[github-issues-52]: https://github.com/surpher/PactSwift/issues/52
 [issues]: https://github.com/surpher/PactSwift/issues
 [license]: LICENSE.md
 [matchers]: https://github.com/surpher/pact-swift/wiki/Matchers
@@ -304,7 +309,6 @@ Logo and branding images provided by [@cjmlgrto](https://github.com/cjmlgrto).
 [pact-twitter]: http://twitter.com/pact_up
 [releases]: https://github.com/surpher/PactSwift/releases
 [rust-lang-installation]: https://www.rust-lang.org/tools/install
-
 [project-ios]: https://github.com/surpher/pact-swift-examples/tree/master/Pact-iOS-Example
 [workflow-ios]: https://github.com/surpher/pact-swift-examples/actions?query=workflow%3A%22Test+iOS+project%22
 [project-ios-spm]: https://github.com/surpher/pact-swift-examples/tree/master/Pact-iOS-SPM-Example

--- a/Scripts/BuildPhases/build-spm-dependency
+++ b/Scripts/BuildPhases/build-spm-dependency
@@ -42,15 +42,26 @@ else
 fi
 
 # Build the libpact_mock_server_ffi binary
-# Add target triples
-rustup target add aarch64-apple-ios x86_64-apple-ios x86_64-apple-darwin
+# Change to nighly toolchain
+rustup install nightly
+RUSTUP_UPDATE_ROOT=https://dev-static.rust-lang.org/rustup sh <(curl --proto '=https' --tlsv1.2 -sSf https://dev-static.rust-lang.org/rustup/rustup-init.sh) --default-toolchain beta
+rustup default nightly-x86_64-apple-darwin
+
+# Add required target triples
+rustup target add aarch64-apple-ios aarch64-apple-darwin x86_64-apple-ios x86_64-apple-darwin
 
 # Change into Submodules' dependency folder
 cd $PACTSWIFT_SRC_DIR
 
 if [[ $PLATFORM == "macos" ]]; then
-	# Build the Rust dependency for darwin architecture
-	cargo build --release --target=x86_64-apple-darwin
+	# Build the Rust dependency for darwin
+	CURRENT_ARCH="$(uname -m)"
+	if [[ $CURRENT_ARCH == "x86_64" ]]; then
+		cargo build --release --target=x86_64-apple-darwin
+	else
+		cargo build --release --target=aarm64-apple-darwin
+	fi
+
 	# Change back to $SRCROOT
 	cd $SRCROOT_DIR
 	# Rename the build binary for macOS // replace RUST_MACOS_BUILD_DIR

--- a/Scripts/carthage_xcode12
+++ b/Scripts/carthage_xcode12
@@ -3,7 +3,9 @@
 # carthage_xcode12
 # Usage example: ./carthage_xcode12 build --platform iOS
 #
-# Author: https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
+# Sources:
+# - https://github.com/Carthage/Carthage/issues/3019#issuecomment-665136323
+# - https://github.com/Carthage/Carthage/issues/3019#issuecomment-734415287
 
 set -euo pipefail
 

--- a/Scripts/run_tests
+++ b/Scripts/run_tests
@@ -4,7 +4,7 @@ set -xeu
 set -o pipefail
 
 # Overridable Environment
-SIMULATOR_NAME=${SIMULATOR_NAME:-'iPhone 11 Pro'}
+SIMULATOR_NAME=${SIMULATOR_NAME:-'iPhone 12 Pro'}
 
 # Check for dependencies
 if ! [ -x "$(command -v xcbeautify)" ]; then


### PR DESCRIPTION
# 📝 Summary of Changes

`arm64` and `arm64e` architectures for macOS are not yet fully (and painlessly) supported by all the tools and dependencies when dealing with PactSwift and specifically the Rust `libpact_mock_server.a`. Building the `libpact_mock_server.a` binary with `aarch64-apple-darwin` triple continues to fail. As `arm64` is still scarce in the wild, I decided to exclude from valid architectures for macOS target for now. 

# ⚠️ Items of Note

- Relates to $52

# 🧐🗒 Reviewer Notes

I'm keeping a close eye on the progress of `aarch64-apple-darwin` availability. As soon as it is available in the stable toolchain and building the dependencies succeeds, this will be reverted.

## 🔨 How To Test

- [ ] CI passes