### PR TITLE
tech: Extracts build phase steps into standalone scripts

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,7 +7,6 @@ env:
 on:
   push:
     branches:
-      - main
       - 'tech/**'
       - 'fix/**'
       - 'feat/**'

--- a/.github/workflows/pull_request_xcode_11.6.yml
+++ b/.github/workflows/pull_request_xcode_11.6.yml
@@ -1,7 +1,8 @@
 name: Pull Request (Xcode 11.6)
 
 env:
-    SIMULATOR_NAME: "iPhone 11 Pro"
+  RUST_BUILD_OUTPUT_DIR: "build/rust"
+  RUST_BINARY_DIR: "build/rust/x86_64-apple-darwin/release"
 
 on:
   pull_request:

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PROJECT_DIR}\"/Scripts/BuildPhases/cargo-build-macos\n";
+			shellScript = "\"${PROJECT_DIR}\"/Scripts/BuildPhases/cargo-build-ios\n";
 		};
 		AD8FC7CF2463A08900361854 /* Lint Target */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 				AD8FC7D02463A09900361854 /* Lint Project */,
 				AD8FC7CF2463A08900361854 /* Lint Target */,
 				AD8FC7D12463A0A100361854 /* Swiftlint */,
-				ADE512E625352C370020EF57 /* Build libpact_mock_server.a static library  - `cargo build --release` */,
+				ADE512E625352C370020EF57 /* Build libpact_mock_server.a static library */,
 				AD8FC7B32463A06F00361854 /* Sources */,
 				AD8FC7B42463A06F00361854 /* Frameworks */,
 				AD8FC7B52463A06F00361854 /* Resources */,
@@ -872,7 +872,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH=\"$HOME/.cargo/bin:$PATH\"\n\nrustup target add x86_64-apple-ios\nrustup target add aarch64-apple-ios\ncargo install cargo-lipo\ncd Submodules/pact-reference/rust/pact_mock_server_ffi && cargo lipo --release\n\ncp \"$PROJECT_DIR/Submodules/pact-reference/rust/target/universal/release/libpact_mock_server_ffi.a\" \"$PROJECT_DIR/Resources/iOS/libpact_mock_server.a\"\n\n";
+			shellScript = "\"${PROJECT_DIR}\"/Scripts/BuildPhases/cargo-build-macos\n";
 		};
 		AD8FC7CF2463A08900361854 /* Lint Target */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -928,7 +928,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Run SwiftLint before even attempting to compile\n./Scripts/build_file_list_and_swiftlint PactSwift ./.swiftlint.yml\n";
+			shellScript = "# Run SwiftLint before even attempting to compile\n\"${PROJECT_DIR}\"/Scripts/build_file_list_and_swiftlint PactSwift ./.swiftlint.yml\n";
 		};
 		ADC3C4CC242CCCEB00D3FDCE /* Lint Project */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1002,9 +1002,9 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Run SwiftLint before even attempting to compile\n./Scripts/build_file_list_and_swiftlint PactSwift ./.swiftlint.yml\n";
+			shellScript = "# Run SwiftLint before even attempting to compile\n\"${PROJECT_DIR}\"/Scripts/build_file_list_and_swiftlint PactSwift ./.swiftlint.yml\n";
 		};
-		ADE512E625352C370020EF57 /* Build libpact_mock_server.a static library  - `cargo build --release` */ = {
+		ADE512E625352C370020EF57 /* Build libpact_mock_server.a static library */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1013,14 +1013,14 @@
 			);
 			inputPaths = (
 			);
-			name = "Build libpact_mock_server.a static library  - `cargo build --release`";
+			name = "Build libpact_mock_server.a static library";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "PATH=\"$HOME/.cargo/bin:$PATH\"\nexport RUST_BUILD_OUTPUT_DIR=\"$PROJECT_DIR/build\"\nmkdir -p $RUST_BUILD_OUTPUT_DIR\n\ncd Submodules/pact-reference/rust/pact_mock_server_ffi && cargo build --release --target-dir $RUST_BUILD_OUTPUT_DIR\n\ncp $RUST_BUILD_OUTPUT_DIR/release/deps/libpact_mock_server_ffi.a \"$PROJECT_DIR/Resources/macOS/libpact_mock_server.a\"\n";
+			shellScript = "\"${PROJECT_DIR}\"/Scripts/BuildPhases/cargo-build-macos\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Scripts/BuildPhases/build-spm-dependency
+++ b/Scripts/BuildPhases/build-spm-dependency
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 
-set -xeu
+set -eu
 set -o pipefail
 
 # Check for dependencies
 echo "--- 👮‍♀️ Checking if Rust is installed..."
 
 if which cargo >/dev/null; then
-	echo "--- 👍 cargo installed"
+	echo "👍  cargo installed"
 elif command -v ~/.cargo/bin/cargo &> /dev/null; then
-	PATH="$HOME/.cargo/bin:$PATH"
-	echo "--- 👍 cargo installed in ~/.cargo/bin/"
+	echo "👍  cargo installed in ~/.cargo/bin/"
 else
-	echo "--- 🚨 Rust not installed"
-	echo "ERROR: cargo is required and is not found, not even in `~/.cargo/bin`.\nInstall Rust using either homebrew or follow instructions at https://www.rust-lang.org/tools/install"
+	echo "🚨  Rust not installed"
+	echo "ERROR: cargo is required and is not found in `~/.cargo/bin`. Install Rust using either homebrew or follow instructions at https://www.rust-lang.org/tools/install"
 	exit 1
 fi
 

--- a/Scripts/BuildPhases/cargo-build-ios
+++ b/Scripts/BuildPhases/cargo-build-ios
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+PATH="$HOME/.cargo/bin:$PATH"
+
+rustup target add x86_64-apple-ios
+rustup target add aarch64-apple-ios
+cargo install cargo-lipo
+
+cd Submodules/pact-reference/rust/pact_mock_server_ffi && cargo lipo --release
+
+cp "${PROJECT_DIR}/Submodules/pact-reference/rust/target/universal/release/libpact_mock_server_ffi.a" "$PROJECT_DIR/Resources/iOS/libpact_mock_server.a"

--- a/Scripts/BuildPhases/cargo-build-macos
+++ b/Scripts/BuildPhases/cargo-build-macos
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+PATH="$HOME/.cargo/bin:$PATH"
+export RUST_BUILD_OUTPUT_DIR="$PROJECT_DIR/build"
+mkdir -p $RUST_BUILD_OUTPUT_DIR
+
+cd Submodules/pact-reference/rust/pact_mock_server_ffi && cargo build --release --target-dir $RUST_BUILD_OUTPUT_DIR
+
+cp $RUST_BUILD_OUTPUT_DIR/release/deps/libpact_mock_server_ffi.a "$PROJECT_DIR/Resources/macOS/libpact_mock_server.a"

--- a/Scripts/build_file_list_and_swiftlint
+++ b/Scripts/build_file_list_and_swiftlint
@@ -49,15 +49,3 @@ else
 	echo "--- ⚠️ Swiftlint"
 	echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
 fi
-
-echo "--- 🤖 Checking if Rust is installed..."
-
-if which cargo >/dev/null; then
-	echo "--- 👍 cargo installed"
-elif command -v ~/.cargo/bin/cargo &> /dev/null; then
-	echo "--- 👍 cargo installed in ~/.cargo/bin/"
-else
-	echo "--- 🚨 Rust not installed"
-	echo "ERROR: cargo is required and is not found in `~/.cargo/bin`. Install Rust using either homebrew or follow instructions at https://www.rust-lang.org/tools/install"
-	exit 1
-fi

--- a/Scripts/check_build_tools
+++ b/Scripts/check_build_tools
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+# Checking for Rust
+echo "--- 🤖  Checking if Rust is installed..."
+
+if which cargo >/dev/null; then
+	echo "👍  cargo installed"
+elif command -v ~/.cargo/bin/cargo &> /dev/null; then
+	echo "👍  cargo installed in ~/.cargo/bin/"
+else
+	echo "🚨  Rust not installed"
+	echo "ERROR: cargo is required and is not found in `~/.cargo/bin`. Install Rust using either homebrew or follow instructions at https://www.rust-lang.org/tools/install"
+	exit 1
+fi
+
+# Checking for SwiftLint
+if which swiftlint >/dev/null; then
+	echo "👍  SwiftLint installed"
+else
+	echo "⚠️  Swiftlint"
+	echo "warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint"
+fi

--- a/Scripts/run_tests
+++ b/Scripts/run_tests
@@ -1,21 +1,37 @@
 #!/usr/bin/env bash
 
-set -xeu
+set -eu
 set -o pipefail
 
 # Overridable Environment
 SIMULATOR_NAME=${SIMULATOR_NAME:-'iPhone 12 Pro'}
+SCRIPTS_DIR="${BASH_SOURCE[0]%/*}"
 
 # Check for dependencies
-if ! [ -x "$(command -v xcbeautify)" ]; then
-  echo 'Error: xcbeautify is not installed.' >&2
-  exit 1
-fi
+$SCRIPTS_DIR/check_build_tools
+
+# # Run iOS tests
+echo "--- 📱  Running iOS tests"
+set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-iOS -destination "platform=iOS Simulator,name=iPhone 12 Pro" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcbeautify
+
+# # Run macOS tests
+echo "--- 🖥  Running macOS tests"
+set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-macOS -destination "platform=macOS,arch=x86_64" GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES| xcbeautify
+
+# Carthage build
+echo "--- 📦  Building as a Carthage dependency"
+${SCRIPTS_DIR}/carthage_xcode12 build --no-skip-current
 
 # Build and test for SPM
+echo "--- 🏗  Building swift (SPM)"
 swift build -c debug
 swift test -Xlinker -LResources/macOS
 
 # Run tests
+echo "--- 📱  Running iOS tests (SPM)"
 set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-iOS -destination "platform=iOS Simulator,name=${SIMULATOR_NAME}" | xcbeautify
+
+echo "--- 🖥  Running macOS tests (SPM) - x86_64"
 set -o pipefail && xcodebuild clean test -project PactSwift.xcodeproj -scheme PactSwift-macOS -destination "platform=OS X,arch=x86_64" | xcbeautify
+
+echo "👍  All hunky dory!"


### PR DESCRIPTION
# 📝 Summary of Changes

Takes the scripts in BuildPhases (specifically for building Rust dependencies) and moves them into a couple new bash script files that can be reused and referenced to, along with option to be used in CI pipelines.

Cleans up some existing scripts.

## 🔨 How To Test

- [ ] CI passes
