### PR TITLE
feature: Set the format using RandomUUID example generator

### DIFF
--- a/Sources/ExampleGenerators/RandomUUID.swift
+++ b/Sources/ExampleGenerators/RandomUUID.swift
@@ -26,22 +26,31 @@ public extension ExampleGenerator {
 		internal let rules: [String: AnyEncodable]? = nil
 
 		/// Generates a random UUID value
-		public init(format: Format = .uppercaseDashed) {
+		public init(format: Format = .uppercaseHyphenated) {
 			let uuid = UUID()
 			self.value = {
 				switch format {
-				case .uppercaseDashed: return uuid.uuidString
-				case .dashed: return uuid.rfc4122String
 				case .simple: return uuid.uuidStringSimple
+				case .lowercaseHyphenated: return uuid.rfc4122String
+				case .uppercaseHyphenated: return uuid.uuidString
+				case .urn: return "urn:uuid:\(uuid.rfc4122String)"
 				}
 			}()
 		}
 
 		/// The format of the UUID value
-		public enum Format {
-			case uppercaseDashed
-			case dashed
+		public enum Format: String {
+			/// Simple UUID format (eg: 936DA01f9abd4d9d80c702af85c822a8)
 			case simple
+
+			/// Lowercase hyphenated format (eg: 936da01f-9abd-4d9d-80c7-02af85c822a8)
+			case lowercaseHyphenated = "lower-case-hyphenated"
+
+			/// Uppercase hyphenated format (eg: 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
+			case uppercaseHyphenated = "upper-case-hyphenated"
+
+			/// URN format (eg: urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
+			case urn = "URN"
 		}
 	}
 

--- a/Sources/ExampleGenerators/RandomUUID.swift
+++ b/Sources/ExampleGenerators/RandomUUID.swift
@@ -26,7 +26,7 @@ public extension ExampleGenerator {
 		internal let rules: [String: AnyEncodable]? = nil
 
 		/// Generates a random UUID value
-		public init(_ format: Format = .uppercaseDashed) {
+		public init(format: Format = .uppercaseDashed) {
 			let uuid = UUID()
 			self.value = {
 				switch format {

--- a/Sources/ExampleGenerators/RandomUUID.swift
+++ b/Sources/ExampleGenerators/RandomUUID.swift
@@ -21,12 +21,28 @@ public extension ExampleGenerator {
 
 	/// Generates a random UUID value
 	struct RandomUUID: ExampleGeneratorExpressible {
-		internal let value: Any = UUID().rfc4122String
+		internal let value: Any
 		internal let generator: ExampleGenerator.Generator = .uuid
 		internal let rules: [String: AnyEncodable]? = nil
 
 		/// Generates a random UUID value
-		public init() { }
+		public init(_ format: Format = .uppercaseDashed) {
+			let uuid = UUID()
+			self.value = {
+				switch format {
+				case .uppercaseDashed: return uuid.uuidString
+				case .dashed: return uuid.rfc4122String
+				case .simple: return uuid.uuidStringSimple
+				}
+			}()
+		}
+
+		/// The format of the UUID value
+		public enum Format {
+			case uppercaseDashed
+			case dashed
+			case simple
+		}
 	}
 
 }

--- a/Tests/ExampleGenerators/RandomUuidTests.swift
+++ b/Tests/ExampleGenerators/RandomUuidTests.swift
@@ -29,10 +29,57 @@ class RandomUUIDTests: XCTestCase {
 		XCTAssertNil(sut.rules)
 	}
 
+	func testSimpleRandomUUIDExampleGenerator() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .simple)
+
+		let uuid = try XCTUnwrap(sut.value as? String)
+		XCTAssertEqual(uuid.count, 32)
+		XCTAssert(uuid.allSatisfy {
+			$0.isNumber || $0.isASCIILetter
+		})
+	}
+
+	func testLowercaseHyphenatedRandomUUIDExampleGenerator() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .lowercaseHyphenated)
+
+		let uuid = try XCTUnwrap(sut.value as? String)
+		XCTAssertEqual(uuid.count, 36)
+		XCTAssert(uuid.allSatisfy {
+			$0 == "-" || $0.isNumber || $0.isASCIILetter && $0.isLowercase
+		})
+	}
+
+	func testUppercaseHyphenatedRandomUUIDExampleGenerator() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .uppercaseHyphenated)
+
+		let uuid = try XCTUnwrap(sut.value as? String)
+		XCTAssertEqual(uuid.count, 36)
+		XCTAssert(uuid.allSatisfy {
+			$0 == "-" || $0.isNumber || $0.isASCIILetter && $0.isUppercase
+		})
+	}
+
+	func testURNRandomUUIDExampleGenerator() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .urn)
+
+		let urn = try XCTUnwrap(sut.value as? String)
+		XCTAssertEqual(urn.prefix(9), "urn:uuid:")
+		let uuid = urn.dropFirst(9)
+		XCTAssertEqual(uuid.count, 36)
+		XCTAssert(uuid.allSatisfy {
+			$0 == "-" || $0.isNumber || $0.isASCIILetter && $0.isLowercase
+		})
+	}
+
 	func testSimpleUUID() {
 		let sut = UUID()
 		XCTAssertEqual(sut.uuidString.count, 36)
 		XCTAssertEqual(sut.uuidStringSimple.count, 32)
 	}
+}
 
+private extension Character {
+	var isASCIILetter: Bool {
+		isASCII && isLetter
+	}
 }


### PR DESCRIPTION
# 📝 Summary of Changes
This pull request resolves issue #70 by allowing to set the format of `RandomUUID` example generator.

# 🧐🗒 Reviewer Notes
Of course, I understand that this functionality should be covered by unit tests. But I'm not sure, to which test suite they should be added.