### PR TITLE
feat: Enhanced RandomUUID example generator

### DIFF
--- a/Sources/ExampleGenerators/RandomUUID.swift
+++ b/Sources/ExampleGenerators/RandomUUID.swift
@@ -71,12 +71,15 @@ public class ObjcRandomUUID: NSObject, ObjcGenerator {
 
 	/// Generates a random UUID value in desired format
 	///
-	///     // 1 : Simple UUID format (eg: 936DA01f9abd4d9d80c702af85c822a8)
-	///     // 2 : Lowercase hyphenated format (eg: 936da01f-9abd-4d9d-80c7-02af85c822a8)
-	///     // 3 : Uppercase hyphenated format (eg: 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
-	///     // 4 : URN format (eg: urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
+	///     // 0 - Simple UUID format (eg: 936DA01f9abd4d9d80c702af85c822a8)
+	///     // 1 - Lowercase hyphenated format (eg: 936da01f-9abd-4d9d-80c7-02af85c822a8)
+	///     // 2 - Uppercase hyphenated format (eg: 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
+	///     // 3 - URN format (eg: urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
 	///
-	///     PFGeneratorRandomUUID *randomUUID = [[PFGeneratorRandomUUID alloc] initWithFormat: 3];
+	///     // Using with enum Int id:
+	///     PFGeneratorRandomUUID *randomUUID = [[PFGeneratorRandomUUID alloc] initWithFormat: 2];
+	///     // or using enum case:
+	///     PFGeneratorRandomUUID *randomUUID = [[PFGeneratorRandomUUID alloc] initWithFormat: ObjcUUIDFormatUppercaseHyphenated];
 	///
 	@objc(initWithFormat:)
 	public init(format: ObjcUUIDFormat) {

--- a/Sources/ExampleGenerators/RandomUUID.swift
+++ b/Sources/ExampleGenerators/RandomUUID.swift
@@ -23,10 +23,31 @@ public extension ExampleGenerator {
 	struct RandomUUID: ExampleGeneratorExpressible {
 		internal let value: Any = UUID().rfc4122String
 		internal let generator: ExampleGenerator.Generator = .uuid
-		internal let rules: [String: AnyEncodable]? = nil
+		internal let rules: [String: AnyEncodable]?
 
 		/// Generates a random UUID value
-		public init() { }
+		///
+		/// - Parameters:
+		///   - format: The format of UUID to generate
+		///
+		public init(format: Format = .uppercaseHyphenated) {
+			self.rules = ["format": AnyEncodable(format.rawValue)]
+		}
+
+		/// The format of the UUID value
+		public enum Format: String {
+			/// Simple UUID format (eg: 936DA01f9abd4d9d80c702af85c822a8)
+			case simple
+
+			/// Lowercase hyphenated format (eg: 936da01f-9abd-4d9d-80c7-02af85c822a8)
+			case lowercaseHyphenated = "lower-case-hyphenated"
+
+			/// Uppercase hyphenated format (eg: 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
+			case uppercaseHyphenated = "upper-case-hyphenated"
+
+			/// URN format (eg: urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
+			case urn = "URN"
+		}
 	}
 
 }
@@ -37,11 +58,49 @@ public extension ExampleGenerator {
 @objc(PFGeneratorRandomUUID)
 public class ObjcRandomUUID: NSObject, ObjcGenerator {
 
-	let type: ExampleGeneratorExpressible = ExampleGenerator.RandomUUID()
+	let type: ExampleGeneratorExpressible
 
 	/// Generates a random UUID value
+	///
+	/// Uses default lower-case-hyphenated format
 	public override init() {
+		type = ExampleGenerator.RandomUUID()
+
 		super.init()
+	}
+
+	/// Generates a random UUID value in desired format
+	///
+	///     // 1 : Simple UUID format (eg: 936DA01f9abd4d9d80c702af85c822a8)
+	///     // 2 : Lowercase hyphenated format (eg: 936da01f-9abd-4d9d-80c7-02af85c822a8)
+	///     // 3 : Uppercase hyphenated format (eg: 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
+	///     // 4 : URN format (eg: urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
+	///
+	///     PFGeneratorRandomUUID *randomUUID = [[PFGeneratorRandomUUID alloc] initWithFormat: 3];
+	///
+	@objc(initWithFormat:)
+	public init(format: ObjcUUIDFormat) {
+		type = ExampleGenerator.RandomUUID(format: format.bridged)
+
+		super.init()
+	}
+
+	/// The format of the UUID value
+	@objc public enum ObjcUUIDFormat: Int {
+		case simple = 0
+		case lowercaseHyphenated = 1
+		case uppercaseHyphenated = 2
+		case urn = 3
+
+		// Bridges the ObjC.RandomUUID.Format to Swift.RandomUUID.Format
+		fileprivate var bridged: ExampleGenerator.RandomUUID.Format {
+			switch self {
+			case .simple: return .simple
+			case .lowercaseHyphenated: return .lowercaseHyphenated
+			case .uppercaseHyphenated: return .uppercaseHyphenated
+			case .urn: return .urn
+			}
+		}
 	}
 
 }

--- a/Tests/ExampleGenerators/ObjCExampleGeneratorTests.swift
+++ b/Tests/ExampleGenerators/ObjCExampleGeneratorTests.swift
@@ -85,6 +85,12 @@ class ObjCExampleGeneratorTests: XCTestCase {
 		XCTAssertTrue((testSubject.type as Any) is ExampleGenerator.RandomUUID)
 	}
 
+	func testObjCExampleGenerators_InitsWith_RandomUUIDFormat() {
+		let testSubject = ObjcRandomUUID(format: .uppercaseHyphenated)
+
+		XCTAssertTrue((testSubject.type as Any) is ExampleGenerator.RandomUUID)
+	}
+
 }
 
 #endif

--- a/Tests/ExampleGenerators/RandomUuidTests.swift
+++ b/Tests/ExampleGenerators/RandomUuidTests.swift
@@ -31,56 +31,37 @@ class RandomUUIDTests: XCTestCase {
 
 	func testRandomUUIDDefaultFormat() throws {
 		let sut = ExampleGenerator.RandomUUID()
-		let result = try encodeDecode(sut.rules!)
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
 
 		XCTAssertEqual(result.format, "upper-case-hyphenated")
 	}
 
 	func testRandomUUIDUpperCaseHyphenatedFormat() throws {
 		let sut = ExampleGenerator.RandomUUID()
-		let result = try encodeDecode(sut.rules!)
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
 
 		XCTAssertEqual(result.format, "upper-case-hyphenated")
 	}
 
 	func testRandomUUIDSimpleFormat() throws {
 		let sut = ExampleGenerator.RandomUUID(format: .simple)
-		let result = try encodeDecode(sut.rules!)
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
 
 		XCTAssertEqual(result.format, "simple")
 	}
 
 	func testRandomUUIDLowerCaseHyphenatedFormat() throws {
 		let sut = ExampleGenerator.RandomUUID(format: .lowercaseHyphenated)
-		let result = try encodeDecode(sut.rules!)
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
 
 		XCTAssertEqual(result.format, "lower-case-hyphenated")
 	}
 
 	func testRandomUUIDURNFormat() throws {
 		let sut = ExampleGenerator.RandomUUID(format: .urn)
-		let result = try encodeDecode(sut.rules!)
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
 
 		XCTAssertEqual(result.format, "URN")
-	}
-
-}
-
-// MARK: - Test Utilities
-
-private extension RandomUUIDTests {
-
-	struct EncodableModel: Encodable {
-		var params: [String: AnyEncodable]
-	}
-
-	struct DecodableModel: Decodable {
-		var format: String
-	}
-
-	func encodeDecode(_ model: [String: AnyEncodable]) throws -> DecodableModel {
-		let data = try JSONEncoder().encode(EncodableModel(params: model).params)
-		return try JSONDecoder().decode(DecodableModel.self, from: data)
 	}
 
 }

--- a/Tests/ExampleGenerators/RandomUuidTests.swift
+++ b/Tests/ExampleGenerators/RandomUuidTests.swift
@@ -26,13 +26,61 @@ class RandomUUIDTests: XCTestCase {
 
 		XCTAssertNotNil(UUID(uuidString: try XCTUnwrap(sut.value as? String)))
 		XCTAssertEqual(sut.generator, .uuid)
-		XCTAssertNil(sut.rules)
+		XCTAssertNotNil(sut.rules)
 	}
 
-	func testSimpleUUID() {
-		let sut = UUID()
-		XCTAssertEqual(sut.uuidString.count, 36)
-		XCTAssertEqual(sut.uuidStringSimple.count, 32)
+	func testRandomUUIDDefaultFormat() throws {
+		let sut = ExampleGenerator.RandomUUID()
+		let result = try encodeDecode(sut.rules!)
+
+		XCTAssertEqual(result.format, "upper-case-hyphenated")
+	}
+
+	func testRandomUUIDUpperCaseHyphenatedFormat() throws {
+		let sut = ExampleGenerator.RandomUUID()
+		let result = try encodeDecode(sut.rules!)
+
+		XCTAssertEqual(result.format, "upper-case-hyphenated")
+	}
+
+	func testRandomUUIDSimpleFormat() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .simple)
+		let result = try encodeDecode(sut.rules!)
+
+		XCTAssertEqual(result.format, "simple")
+	}
+
+	func testRandomUUIDLowerCaseHyphenatedFormat() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .lowercaseHyphenated)
+		let result = try encodeDecode(sut.rules!)
+
+		XCTAssertEqual(result.format, "lower-case-hyphenated")
+	}
+
+	func testRandomUUIDURNFormat() throws {
+		let sut = ExampleGenerator.RandomUUID(format: .urn)
+		let result = try encodeDecode(sut.rules!)
+
+		XCTAssertEqual(result.format, "URN")
+	}
+
+}
+
+// MARK: - Test Utilities
+
+private extension RandomUUIDTests {
+
+	struct EncodableModel: Encodable {
+		var params: [String: AnyEncodable]
+	}
+
+	struct DecodableModel: Decodable {
+		var format: String
+	}
+
+	func encodeDecode(_ model: [String: AnyEncodable]) throws -> DecodableModel {
+		let data = try JSONEncoder().encode(EncodableModel(params: model).params)
+		return try JSONDecoder().decode(DecodableModel.self, from: data)
 	}
 
 }

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -153,15 +153,19 @@ class PactContractTests: XCTestCase {
 				// MARK: - Validate Generators
 
 				let responseGenerators = try extract(.generators, in: .response, interactions: interactions, description: "Request for list of users")
-				let expectedGenerators = [
-					"$.array_of_arrays[*][2]": "Uuid"
+				let expectedGeneratorsType = [
+					"$.array_of_arrays[*][2]": [
+						"type": "Uuid",
+						"format": "upper-case-hyphenated"
+					]
 				]
 
 				assert(
-					expectedGenerators.allSatisfy { expectedKey, expectedValue -> Bool in
+					expectedGeneratorsType.allSatisfy { expectedKey, expectedValue -> Bool in
 						responseGenerators.contains { generatedKey, generatedValue -> Bool in
 							expectedKey == generatedKey
-							&& expectedValue == (generatedValue as? [String: String])?["type"]
+							&& expectedValue["type"] == (generatedValue as? [String: String])?["type"]
+							&& expectedValue["format"] == (generatedValue as? [String: String])?["format"]
 						}
 					},
 					"Not all expected generators found in Pact contract file"
@@ -412,7 +416,7 @@ class PactContractTests: XCTestCase {
 						[
 							Matcher.SomethingLike("array_value"),
 							Matcher.RegexLike(value: "2021-05-15", pattern: #"\d{4}-\d{2}-\d{2}"#),
-							ExampleGenerator.RandomUUID(),
+							ExampleGenerator.RandomUUID(format: .uppercaseHyphenated),
 							Matcher.EachLike(
 								[
 									"3rd_level_nested": Matcher.EachLike(Matcher.IntegerLike(369), count: 2)


### PR DESCRIPTION
# 📝 Summary of Changes

Enhances the RandomUUID example generator by allowing the user to set the format of the generated UUID. It sets the `rules` that are then encoded and passed to the Mock Server. Mock Server re-generates the UUID using the set format.

Resolves #70

# ⚠️ Items of Note

The initial UUID value that is set during RandomUUID object init is throwaway value. It is only set so that the object being encoded is valid.

# 🧐🗒 Reviewer Notes

## 💁 Example

```swift
ExampleGenerator.RandomUUID(format: .simple)
```


## 🔨 How To Test

/ 