### PR TITLE
feat: Add support for datetime expressions

### DIFF
--- a/PactSwift.xcfilelist
+++ b/PactSwift.xcfilelist
@@ -51,6 +51,7 @@ $(SRCROOT)/Sources/ExampleGenerators/RandomDateTime.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomDecimal.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomHexadecimal.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomInt.swift
+$(SRCROOT)/Sources/ExampleGenerators/DateTimeExpression.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomTime.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomUUID.swift
 $(SRCROOT)/Sources/ExampleGenerators/ExampleGenerator.swift

--- a/PactSwift.xcfilelist
+++ b/PactSwift.xcfilelist
@@ -56,4 +56,5 @@ $(SRCROOT)/Sources/ExampleGenerators/RandomUUID.swift
 $(SRCROOT)/Sources/ExampleGenerators/ExampleGenerator.swift
 $(SRCROOT)/Sources/ExampleGenerators/RandomDate.swift
 $(SRCROOT)/Sources/ExampleGenerators/ProviderStateGenerator.swift
+$(SRCROOT)/Sources/ExampleGenerators/DateTime.swift
 $(SRCROOT)/Sources/MockService.swift

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		AD641A3E24344FA100785CE1 /* PacticipantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD641A3D24344FA100785CE1 /* PacticipantTests.swift */; };
 		AD641A402434518500785CE1 /* PactTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD641A3F2434518500785CE1 /* PactTests.swift */; };
 		AD641A422434588200785CE1 /* Interaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD641A412434588200785CE1 /* Interaction.swift */; };
+		AD72E54027B89CB900C7453F /* DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72E53F27B89CB900C7453F /* DateTime.swift */; };
+		AD72E54127B89CB900C7453F /* DateTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72E53F27B89CB900C7453F /* DateTime.swift */; };
+		AD72E54527B8A03000C7453F /* DateTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72E54227B8A02200C7453F /* DateTimeTests.swift */; };
+		AD72E54627B8A03100C7453F /* DateTimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD72E54227B8A02200C7453F /* DateTimeTests.swift */; };
 		AD7891B724414D500014BCC8 /* PactBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7891B624414D500014BCC8 /* PactBuilderTests.swift */; };
 		AD7891BA2441512E0014BCC8 /* SomethingLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7891B92441512E0014BCC8 /* SomethingLikeTests.swift */; };
 		AD7891BC244156FC0014BCC8 /* EachLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD7891BB244156FC0014BCC8 /* EachLikeTests.swift */; };
@@ -271,6 +275,8 @@
 		AD641A3D24344FA100785CE1 /* PacticipantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PacticipantTests.swift; sourceTree = "<group>"; };
 		AD641A3F2434518500785CE1 /* PactTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactTests.swift; sourceTree = "<group>"; };
 		AD641A412434588200785CE1 /* Interaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interaction.swift; sourceTree = "<group>"; };
+		AD72E53F27B89CB900C7453F /* DateTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTime.swift; sourceTree = "<group>"; };
+		AD72E54227B8A02200C7453F /* DateTimeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeTests.swift; sourceTree = "<group>"; };
 		AD7891B624414D500014BCC8 /* PactBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactBuilderTests.swift; sourceTree = "<group>"; };
 		AD7891B92441512E0014BCC8 /* SomethingLikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomethingLikeTests.swift; sourceTree = "<group>"; };
 		AD7891BB244156FC0014BCC8 /* EachLikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachLikeTests.swift; sourceTree = "<group>"; };
@@ -650,6 +656,7 @@
 		ADD031622512199500C6099B /* ExampleGenerators */ = {
 			isa = PBXGroup;
 			children = (
+				AD72E53F27B89CB900C7453F /* DateTime.swift */,
 				ADD03163251219B700C6099B /* ExampleGenerator.swift */,
 				AD9D7D8C26C8AD3400FE4137 /* ProviderStateGenerator.swift */,
 				ADD03166251220FD00C6099B /* RandomBool.swift */,
@@ -668,6 +675,7 @@
 		ADD031692512218500C6099B /* ExampleGenerators */ = {
 			isa = PBXGroup;
 			children = (
+				AD72E54227B8A02200C7453F /* DateTimeTests.swift */,
 				ADEDDF112547D95700A45AD2 /* ObjCExampleGeneratorTests.swift */,
 				ADF959CC26C8F98800C35536 /* ProviderStateGeneratorTests.swift */,
 				ADD0316B251221A300C6099B /* RandomBooleanTests.swift */,
@@ -1057,6 +1065,7 @@
 				ADA17E3B25137716004F1A82 /* RandomDateTime.swift in Sources */,
 				ADE9B3C7250A3C4700274672 /* Matcher.swift in Sources */,
 				ADD031782512425800C6099B /* RandomInt.swift in Sources */,
+				AD72E54027B89CB900C7453F /* DateTime.swift in Sources */,
 				AD9D7D8D26C8AD3400FE4137 /* ProviderStateGenerator.swift in Sources */,
 				ADD3C27624416DAE002E73B9 /* IncludesLike.swift in Sources */,
 				ADD0316F25122E4B00C6099B /* RandomUUID.swift in Sources */,
@@ -1114,6 +1123,7 @@
 				AD4B970825138FCF00C37560 /* RandomDecimalTests.swift in Sources */,
 				ADC3AA3D247CBB550034446E /* IncludesLikeTests.swift in Sources */,
 				ADEDDF122547D95700A45AD2 /* ObjCExampleGeneratorTests.swift in Sources */,
+				AD72E54527B8A03000C7453F /* DateTimeTests.swift in Sources */,
 				AD7891BC244156FC0014BCC8 /* EachLikeTests.swift in Sources */,
 				ADA17E492513808B004F1A82 /* DateHelper.swift in Sources */,
 				AD23310C26E9F08000D984A5 /* MockServiceWithDirectoryPathTests.swift in Sources */,
@@ -1174,6 +1184,7 @@
 				ADA17E3C25137716004F1A82 /* RandomDateTime.swift in Sources */,
 				ADE9B3C8250A3C4700274672 /* Matcher.swift in Sources */,
 				ADD031792512425800C6099B /* RandomInt.swift in Sources */,
+				AD72E54127B89CB900C7453F /* DateTime.swift in Sources */,
 				AD9D7D8E26C8AD3400FE4137 /* ProviderStateGenerator.swift in Sources */,
 				AD8FC7E82463BB9F00361854 /* PactHTTPMethod.swift in Sources */,
 				AD8FC7F72463BBB800361854 /* MatchingRuleExpressible.swift in Sources */,
@@ -1231,6 +1242,7 @@
 				AD4B970725138FCE00C37560 /* RandomDecimalTests.swift in Sources */,
 				ADC3AA3E247CBB550034446E /* IncludesLikeTests.swift in Sources */,
 				ADEDDF132547D95700A45AD2 /* ObjCExampleGeneratorTests.swift in Sources */,
+				AD72E54627B8A03100C7453F /* DateTimeTests.swift in Sources */,
 				AD8FC7FF2463BBD000361854 /* MetadataTests.swift in Sources */,
 				ADA17E4A2513808B004F1A82 /* DateHelper.swift in Sources */,
 				AD23310D26E9F08000D984A5 /* MockServiceWithDirectoryPathTests.swift in Sources */,

--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		AD4B97112513A3DB00C37560 /* RandomString.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4B970F2513A3DB00C37560 /* RandomString.swift */; };
 		AD4B97132513A64700C37560 /* RandomStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4B97122513A64700C37560 /* RandomStringTests.swift */; };
 		AD4B97142513A64700C37560 /* RandomStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD4B97122513A64700C37560 /* RandomStringTests.swift */; };
+		AD54435E27D32DCA00D4C464 /* DateTimeExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD54435D27D32DCA00D4C464 /* DateTimeExpression.swift */; };
+		AD54435F27D32DCA00D4C464 /* DateTimeExpression.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD54435D27D32DCA00D4C464 /* DateTimeExpression.swift */; };
+		AD54436127D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD54436027D3316600D4C464 /* DateTimeExpressionTests.swift */; };
+		AD54436227D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD54436027D3316600D4C464 /* DateTimeExpressionTests.swift */; };
 		AD5E9F0226D375BE0002580D /* ProviderVerifier+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E9F0126D375BE0002580D /* ProviderVerifier+Error.swift */; };
 		AD5E9F0326D375BE0002580D /* ProviderVerifier+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E9F0126D375BE0002580D /* ProviderVerifier+Error.swift */; };
 		AD5E9F0526D4684B0002580D /* WIPPacts.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5E9F0426D4684B0002580D /* WIPPacts.swift */; };
@@ -265,6 +269,8 @@
 		AD4FC5DD242CC2B20039342D /* Project-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Shared.xcconfig"; sourceTree = "<group>"; };
 		AD4FC5DE242CC2C30039342D /* Target-iOS-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Target-iOS-Shared.xcconfig"; sourceTree = "<group>"; };
 		AD4FC5DF242CC2CB0039342D /* Target-iOS-Tests-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Target-iOS-Tests-Shared.xcconfig"; sourceTree = "<group>"; };
+		AD54435D27D32DCA00D4C464 /* DateTimeExpression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeExpression.swift; sourceTree = "<group>"; };
+		AD54436027D3316600D4C464 /* DateTimeExpressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateTimeExpressionTests.swift; sourceTree = "<group>"; };
 		AD5E9F0126D375BE0002580D /* ProviderVerifier+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProviderVerifier+Error.swift"; sourceTree = "<group>"; };
 		AD5E9F0426D4684B0002580D /* WIPPacts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIPPacts.swift; sourceTree = "<group>"; };
 		AD641A322434331300785CE1 /* Bundle+PactSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+PactSwift.swift"; sourceTree = "<group>"; };
@@ -657,6 +663,7 @@
 			isa = PBXGroup;
 			children = (
 				AD72E53F27B89CB900C7453F /* DateTime.swift */,
+				AD54435D27D32DCA00D4C464 /* DateTimeExpression.swift */,
 				ADD03163251219B700C6099B /* ExampleGenerator.swift */,
 				AD9D7D8C26C8AD3400FE4137 /* ProviderStateGenerator.swift */,
 				ADD03166251220FD00C6099B /* RandomBool.swift */,
@@ -675,6 +682,7 @@
 		ADD031692512218500C6099B /* ExampleGenerators */ = {
 			isa = PBXGroup;
 			children = (
+				AD54436027D3316600D4C464 /* DateTimeExpressionTests.swift */,
 				AD72E54227B8A02200C7453F /* DateTimeTests.swift */,
 				ADEDDF112547D95700A45AD2 /* ObjCExampleGeneratorTests.swift */,
 				ADF959CC26C8F98800C35536 /* ProviderStateGeneratorTests.swift */,
@@ -1039,6 +1047,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AD54435E27D32DCA00D4C464 /* DateTimeExpression.swift in Sources */,
 				AD641A3C24344ED400785CE1 /* Pacticipant.swift in Sources */,
 				ADA17E41251377A4004F1A82 /* Date+PactSwift.swift in Sources */,
 				AD879B9D258242AC00F85B0B /* PactSwiftVersion.swift in Sources */,
@@ -1119,6 +1128,7 @@
 				ADEDDF092547CFC200A45AD2 /* ObjCMatcherTests.swift in Sources */,
 				ADEDDF1B2547DF3200A45AD2 /* ToolboxTests.swift in Sources */,
 				AD7891BA2441512E0014BCC8 /* SomethingLikeTests.swift in Sources */,
+				AD54436127D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */,
 				ADA17E4F2513848A004F1A82 /* RandomTimeTests.swift in Sources */,
 				AD4B970825138FCF00C37560 /* RandomDecimalTests.swift in Sources */,
 				ADC3AA3D247CBB550034446E /* IncludesLikeTests.swift in Sources */,
@@ -1158,6 +1168,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AD54435F27D32DCA00D4C464 /* DateTimeExpression.swift in Sources */,
 				AD8FC7E42463BB9F00361854 /* Interaction.swift in Sources */,
 				ADA17E42251377A4004F1A82 /* Date+PactSwift.swift in Sources */,
 				AD879B9E258242AC00F85B0B /* PactSwiftVersion.swift in Sources */,
@@ -1238,6 +1249,7 @@
 				ADEDDF0A2547CFC200A45AD2 /* ObjCMatcherTests.swift in Sources */,
 				ADEDDF1C2547DF3200A45AD2 /* ToolboxTests.swift in Sources */,
 				AD8FC80A2463BBD100361854 /* ErrorCapture.swift in Sources */,
+				AD54436227D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */,
 				ADA17E502513848A004F1A82 /* RandomTimeTests.swift in Sources */,
 				AD4B970725138FCE00C37560 /* RandomDecimalTests.swift in Sources */,
 				ADC3AA3E247CBB550034446E /* IncludesLikeTests.swift in Sources */,

--- a/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
+++ b/PactSwift.xcodeproj/xcshareddata/xcschemes/PactSwift-iOS.xcscheme
@@ -99,7 +99,7 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "PACT_ENABLE_LOGGING"
-            value = "true"
+            value = "all"
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>

--- a/Sources/ExampleGenerators/DateTime.swift
+++ b/Sources/ExampleGenerators/DateTime.swift
@@ -3,7 +3,7 @@
 //  PactSwift
 //
 //  Created by Marko Justinek on 13/2/22.
-//  Copyright © 2022 PACT Foundation. All rights reserved.
+//  Copyright © 2022 Marko Justinek. All rights reserved.
 //
 
 import Foundation
@@ -19,10 +19,10 @@ public extension ExampleGenerator {
 		/// Generates an example value for DateTime using a specific `Date` for consumer tests
 		///
 		/// - Parameters:
-		///   - date: The `Date` object to use in consumer tests
 		///   - format: The format used for datetime
+		///   - use: The `Date` object used in consumer tests
 		///
-		public init(_ date: Date, format: String) {
+		public init(format: String, use date: Date) {
 			self.value = date.formatted(format)
 			self.rules = [
 				"format": AnyEncodable(format),
@@ -43,12 +43,12 @@ public class ObjcDateTime: NSObject, ObjcGenerator {
 	/// Generates an example value for DateTime using a specific `Date` for consumer tests
 	///
 	/// - Parameters:
-	///   - use: The `Date` object used in consumer tests
 	///   - format: The format used for datetime
+	///   - use: The `Date` object used in consumer tests
 	///
 	@objc(date: format:)
-	public init(use date: Date, format: String) {
-		type = ExampleGenerator.DateTime(date, format: format)
+	public init(format: String, use date: Date) {
+		type = ExampleGenerator.DateTime(format: format, use: date)
 	}
 
 }

--- a/Sources/ExampleGenerators/DateTime.swift
+++ b/Sources/ExampleGenerators/DateTime.swift
@@ -1,0 +1,55 @@
+//
+//  DateTime.swift
+//  PactSwift
+//
+//  Created by Marko Justinek on 13/2/22.
+//  Copyright © 2022 PACT Foundation. All rights reserved.
+//
+
+import Foundation
+
+public extension ExampleGenerator {
+
+	/// Generates an example for DateTime using a specific `Date`
+	struct DateTime: ExampleGeneratorExpressible {
+		internal let value: Any
+		internal let generator: ExampleGenerator.Generator = .dateTime
+		internal var rules: [String: AnyEncodable]?
+
+		/// Generates an example value for DateTime using a specific `Date` for consumer tests
+		///
+		/// - Parameters:
+		///   - date: The `Date` object to use in consumer tests
+		///   - format: The format used for datetime
+		///
+		public init(_ date: Date, format: String) {
+			self.value = date.formatted(format)
+			self.rules = [
+				"format": AnyEncodable(format),
+			]
+		}
+	}
+
+}
+
+// MARK: - Objective-C
+
+#if !os(Linux)
+@objc(PFGeneratorDateTime)
+public class ObjcDateTime: NSObject, ObjcGenerator {
+
+	let type: ExampleGeneratorExpressible
+
+	/// Generates an example value for DateTime using a specific `Date` for consumer tests
+	///
+	/// - Parameters:
+	///   - use: The `Date` object used in consumer tests
+	///   - format: The format used for datetime
+	///
+	@objc(date: format:)
+	public init(use date: Date, format: String) {
+		type = ExampleGenerator.DateTime(date, format: format)
+	}
+
+}
+#endif

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -29,11 +29,7 @@ extension ExampleGenerator {
 		/// - Warning: Not all Pact implementations support this type of example generator!
 		///
 		public init(expression: String, format: String) {
-			let date = Date()
-			let dateFormatter = DateFormatter()
-			dateFormatter.dateFormat = format
-
-			self.value = dateFormatter.string(from: date)
+			self.value = Date().formatted(format)
 			self.rules = [
 				"format": AnyEncodable(format),
 				"expression": AnyEncodable(expression),

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -1,0 +1,80 @@
+//
+//  DateTimeExpression.swift
+//  PactSwift
+//
+//  Created by Marko Justinek on 5/3/22.
+//  Copyright © 2022 Marko Justinek. All rights reserved.
+//
+
+import Foundation
+
+extension ExampleGenerator {
+
+	/// Generates a generator for DateTime using an expression
+	///
+	/// Warning:
+	/// Not all Pact impelmentations support this type of example generator!
+	struct DateTimeExpression: ExampleGeneratorExpressible {
+		internal let value: Any
+		internal let generator: ExampleGenerator.Generator = .dateTime
+		internal var rules: [String: AnyEncodable]?
+
+		/// Generates an example generator for DateTime using an expression
+		///
+		/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
+		/// This `String` is used as the value for consumer tests.
+		///
+		/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
+		/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
+		///
+		/// - Parameters:
+		///   - format: The date time format
+		///   - expression: The expression provider should use when verifying
+		///   - use: The `Date` object for the consumer test. It uses the value of `format` in Mock Server's response.
+		///
+		/// - Warning: Not all Pact implementations support this type of example generator!
+		///
+		public init(format: String, expression: String, use date: Date) {
+			let dateFormatter = DateFormatter()
+			dateFormatter.dateFormat = format
+
+			self.value = dateFormatter.string(from: date)
+			self.rules = [
+				"format": AnyEncodable(format),
+				"expression": AnyEncodable(expression),
+			]
+		}
+	}
+
+}
+
+// MARK: - Objective-C
+
+#if !os(Linux)
+@objc(PFGeneratorDateTimeExpression)
+public class OjbcDateTimeExpression: NSObject, ObjcGenerator {
+
+	let type: ExampleGeneratorExpressible
+
+	/// Generates an example generator for DateTime using an expression
+	///
+	/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
+	/// This `String` is used as the value for consumer tests.
+	///
+	/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
+	/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
+	///
+	/// - Parameters:
+	///   - format: The date time format
+	///   - expression: The expression provider should use when verifying
+	///   - use: The `Date` object for the consumer test. It uses the value of `format` in Mock Server's response.
+	///
+	/// - Warning: Not all Pact implementations support this type of example generator!
+	///
+	@objc(format: expression: date:)
+	public init(format: String, expression: String, use date: Date) {
+		type = ExampleGenerator.DateTimeExpression(format: format, expression: expression, use: date)
+	}
+
+}
+#endif

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -34,7 +34,7 @@ extension ExampleGenerator {
 		///
 		/// - Warning: Not all Pact implementations support this type of example generator!
 		///
-		public init(format: String, expression: String, use date: Date) {
+		public init(expression: String, format: String, use date: Date) {
 			let dateFormatter = DateFormatter()
 			dateFormatter.dateFormat = format
 
@@ -72,8 +72,8 @@ public class OjbcDateTimeExpression: NSObject, ObjcGenerator {
 	/// - Warning: Not all Pact implementations support this type of example generator!
 	///
 	@objc(format: expression: date:)
-	public init(format: String, expression: String, use date: Date) {
-		type = ExampleGenerator.DateTimeExpression(format: format, expression: expression, use: date)
+	public init(expression: String, format: String, use date: Date) {
+		type = ExampleGenerator.DateTimeExpression(expression: expression, format: format, use: date)
 	}
 
 }

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -21,20 +21,14 @@ extension ExampleGenerator {
 
 		/// Generates an example generator for DateTime using an expression
 		///
-		/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
-		/// This `String` is used as the value for consumer tests.
-		///
-		/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
-		/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
-		///
 		/// - Parameters:
-		///   - format: The date time format
 		///   - expression: The expression provider should use when verifying
-		///   - use: The `Date` object for the consumer test. It uses the value of `format` in Mock Server's response.
+		///   - format: The date time format
 		///
 		/// - Warning: Not all Pact implementations support this type of example generator!
 		///
-		public init(expression: String, format: String, use date: Date) {
+		public init(expression: String, format: String) {
+			let date = Date()
 			let dateFormatter = DateFormatter()
 			dateFormatter.dateFormat = format
 
@@ -58,22 +52,15 @@ public class OjbcDateTimeExpression: NSObject, ObjcGenerator {
 
 	/// Generates an example generator for DateTime using an expression
 	///
-	/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
-	/// This `String` is used as the value for consumer tests.
-	///
-	/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
-	/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
-	///
 	/// - Parameters:
-	///   - format: The date time format
 	///   - expression: The expression provider should use when verifying
-	///   - use: The `Date` object for the consumer test. It uses the value of `format` in Mock Server's response.
+	///   - format: The date time format
 	///
 	/// - Warning: Not all Pact implementations support this type of example generator!
 	///
-	@objc(format: expression: date:)
-	public init(expression: String, format: String, use date: Date) {
-		type = ExampleGenerator.DateTimeExpression(expression: expression, format: format, use: date)
+	@objc(expression: format:)
+	public init(expression: String, format: String) {
+		type = ExampleGenerator.DateTimeExpression(expression: expression, format: format)
 	}
 
 }

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -14,6 +14,7 @@ extension ExampleGenerator {
 	///
 	/// Warning:
 	/// Not all Pact impelmentations support this type of example generator!
+	/// 
 	struct DateTimeExpression: ExampleGeneratorExpressible {
 		internal let value: Any
 		internal let generator: ExampleGenerator.Generator = .dateTime

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension ExampleGenerator {
+public extension ExampleGenerator {
 
 	/// Generates a generator for DateTime using an expression
 	///

--- a/Sources/ExampleGenerators/DateTimeExpression.swift
+++ b/Sources/ExampleGenerators/DateTimeExpression.swift
@@ -14,7 +14,7 @@ extension ExampleGenerator {
 	///
 	/// Warning:
 	/// Not all Pact impelmentations support this type of example generator!
-	/// 
+	///
 	struct DateTimeExpression: ExampleGeneratorExpressible {
 		internal let value: Any
 		internal let generator: ExampleGenerator.Generator = .dateTime

--- a/Sources/ExampleGenerators/RandomDateTime.swift
+++ b/Sources/ExampleGenerators/RandomDateTime.swift
@@ -41,42 +41,6 @@ public extension ExampleGenerator {
 		}
 	}
 
-	/// Generates a generator for DateTime using an expression
-	///
-	/// Warning:
-	/// Not all Pact impelmentations support this type of example generator!
-	struct DateTimeExpression: ExampleGeneratorExpressible {
-		internal let value: Any
-		internal let generator: ExampleGenerator.Generator = .dateTime
-		internal var rules: [String: AnyEncodable]?
-
-		/// Generates an example generator for DateTime using an expression
-		///
-		/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
-		/// This `String` is used as the value for consumer tests.
-		///
-		/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
-		/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
-		///
-		/// - Parameters:
-		///   - format: The date time format
-		///   - expression: The expression provider should use when verifying
-		///   - use: The `Date` object for the consumer test. It uses the value of `format` to prepare the value the Mock Server will return.
-		///
-		/// - Warning: Not all Pact implementations support this type of example generator!
-		///
-		public init(format: String, expression: String, use date: Date) {
-			let dateFormatter = DateFormatter()
-			dateFormatter.dateFormat = format
-
-			self.value = dateFormatter.string(from: date)
-			self.rules = [
-				"format": AnyEncodable(format),
-				"expression": AnyEncodable(expression),
-			]
-		}
-	}
-
 }
 
 // MARK: - Objective-C

--- a/Sources/ExampleGenerators/RandomDateTime.swift
+++ b/Sources/ExampleGenerators/RandomDateTime.swift
@@ -41,6 +41,42 @@ public extension ExampleGenerator {
 		}
 	}
 
+	/// Generates a generator for DateTime using an expression
+	///
+	/// Warning:
+	/// Not all Pact impelmentations support this type of example generator!
+	struct DateTimeExpression: ExampleGeneratorExpressible {
+		internal let value: Any
+		internal let generator: ExampleGenerator.Generator = .dateTime
+		internal var rules: [String: AnyEncodable]?
+
+		/// Generates an example generator for DateTime using an expression
+		///
+		/// It uses Swift's `DateFormatter` to cast the provided `Date` object into `String` with the provided `format`.
+		/// This `String` is used as the value for consumer tests.
+		///
+		/// When defining an expression like `"today +1 day @ 6 o'clock pm"`,
+		/// it is your responsibility to create and pass the `Date` object that fits the expression for the needs of your tests.
+		///
+		/// - Parameters:
+		///   - format: The date time format
+		///   - expression: The expression provider should use when verifying
+		///   - use: The `Date` object for the consumer test. It uses the value of `format` to prepare the value the Mock Server will return.
+		///
+		/// - Warning: Not all Pact implementations support this type of example generator!
+		///
+		public init(format: String, expression: String, use date: Date) {
+			let dateFormatter = DateFormatter()
+			dateFormatter.dateFormat = format
+
+			self.value = dateFormatter.string(from: date)
+			self.rules = [
+				"format": AnyEncodable(format),
+				"expression": AnyEncodable(expression),
+			]
+		}
+	}
+
 }
 
 // MARK: - Objective-C

--- a/Sources/Extensions/Date+PactSwift.swift
+++ b/Sources/Extensions/Date+PactSwift.swift
@@ -36,15 +36,23 @@ extension Date {
 		}
 	}
 
-	static func formattedDate(format: String?, isoFormat: ISOFormat) -> String {
-		guard format != nil else {
-			let formatter = ISO8601DateFormatter()
-			formatter.formatOptions = isoFormat.formatOptions
-			return formatter.string(from: Date())
-		}
+	// MARK: - Instance interface
 
+	func formatted(_ format: String) -> String {
 		let formatter = DateFormatter()
 		formatter.dateFormat = format
+		return formatter.string(from: self)
+	}
+
+	// MARK: - Static interface
+
+	static func formattedDate(format: String?, isoFormat: ISOFormat) -> String {
+		if let format = format {
+			return Date().formatted(format)
+		}
+
+		let formatter = ISO8601DateFormatter()
+		formatter.formatOptions = isoFormat.formatOptions
 		return formatter.string(from: Date())
 	}
 

--- a/Sources/Model/Constants.swift
+++ b/Sources/Model/Constants.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 31/7/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Sources/Model/TransferProtocol.swift
+++ b/Sources/Model/TransferProtocol.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 31/7/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Sources/PFMockService.swift
+++ b/Sources/PFMockService.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 31/7/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Sources/PactBuilder.swift
+++ b/Sources/PactBuilder.swift
@@ -160,6 +160,9 @@ private extension PactBuilder {
 		// NOTE: There is a bug in Swift on macOS 10.x where type casting against a protocol does not work as expected.
 		// Works fine running on macOS 11.x!
 		// That is why each ExampleGenerator type is explicitly stated in its own case statement and is not DRY.
+		case let exampleGenerator as ExampleGenerator.DateTime:
+			processedElement = try processExampleGenerator(exampleGenerator, at: node)
+
 		case let exampleGenerator as ExampleGenerator.RandomBool:
 			processedElement = try processExampleGenerator(exampleGenerator, at: node)
 

--- a/Sources/PactBuilder.swift
+++ b/Sources/PactBuilder.swift
@@ -190,6 +190,9 @@ private extension PactBuilder {
 		case let exampleGenerator as ExampleGenerator.RandomUUID:
 			processedElement = try processExampleGenerator(exampleGenerator, at: node)
 
+		case let exampleGenerator as ExampleGenerator.DateTimeExpression:
+			processedElement = try processExampleGenerator(exampleGenerator, at: node)
+
 		// Anything else is not considered safe to encode in PactSwift
 
 		case let threwError as EncodingError:

--- a/Sources/ProviderVerifier.swift
+++ b/Sources/ProviderVerifier.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 20/8/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Tests/ExampleGenerators/DateTimeExpressionTests.swift
+++ b/Tests/ExampleGenerators/DateTimeExpressionTests.swift
@@ -1,8 +1,8 @@
 //
-//  DateTimeTests.swift
+//  DateTimeExpressionTests.swift
 //  PactSwift
 //
-//  Created by Marko Justinek on 13/2/22.
+//  Created by Marko Justinek on 5/3/22.
 //  Copyright © 2022 Marko Justinek. All rights reserved.
 //
 
@@ -10,18 +10,19 @@ import XCTest
 
 @testable import PactSwift
 
-class DateTimeTests: XCTestCase {
+class DateTimeExpressionTests: XCTestCase {
 
-	func testDateTimeExampleGenerator() throws {
+	func testDateTimeExpressionExampleGenerator() throws {
 		let testDate = Date()
-		let testFormat = "YYYY-MM-DD HH:mm"
-		let sut = ExampleGenerator.DateTime(format: testFormat, use: testDate)
+		let testFormat = "dd.MM.yyyy HH:mm:ss"
+		let testExpression = "tomorrow 5pm"
+		let sut = ExampleGenerator.DateTimeExpression(format: testFormat, expression: testExpression, use: testDate)
 
 		XCTAssertEqual(sut.generator, .dateTime)
 
 		let resultValue = try XCTUnwrap(sut.value as? String)
 		let resultDate = try XCTUnwrap(DateHelper.dateFrom(string: resultValue, format: testFormat))
-		// Assert using the same format due to loss of accuracy using a limited datetime format
+
 		XCTAssertEqual(testDate.formatted(testFormat), resultDate.formatted(testFormat))
 
 		let attributes = try XCTUnwrap(sut.rules)
@@ -29,8 +30,9 @@ class DateTimeTests: XCTestCase {
 			key == "format"
 		})
 
-		let resultFormat = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
-		XCTAssertEqual(resultFormat.format, testFormat)
+		XCTAssertTrue(attributes.contains(where: { key, _ in
+			key == "expression"
+		}))
 	}
 
 }

--- a/Tests/ExampleGenerators/DateTimeExpressionTests.swift
+++ b/Tests/ExampleGenerators/DateTimeExpressionTests.swift
@@ -16,7 +16,7 @@ class DateTimeExpressionTests: XCTestCase {
 		let testDate = Date()
 		let testFormat = "dd.MM.yyyy HH:mm:ss"
 		let testExpression = "tomorrow 5pm"
-		let sut = ExampleGenerator.DateTimeExpression(format: testFormat, expression: testExpression, use: testDate)
+		let sut = ExampleGenerator.DateTimeExpression(expression: testExpression, format: testFormat, use: testDate)
 
 		XCTAssertEqual(sut.generator, .dateTime)
 

--- a/Tests/ExampleGenerators/DateTimeExpressionTests.swift
+++ b/Tests/ExampleGenerators/DateTimeExpressionTests.swift
@@ -16,7 +16,7 @@ class DateTimeExpressionTests: XCTestCase {
 		let testDate = Date()
 		let testFormat = "dd.MM.yyyy HH:mm:ss"
 		let testExpression = "tomorrow 5pm"
-		let sut = ExampleGenerator.DateTimeExpression(expression: testExpression, format: testFormat, use: testDate)
+		let sut = ExampleGenerator.DateTimeExpression(expression: testExpression, format: testFormat)
 
 		XCTAssertEqual(sut.generator, .dateTime)
 

--- a/Tests/ExampleGenerators/DateTimeExpressionTests.swift
+++ b/Tests/ExampleGenerators/DateTimeExpressionTests.swift
@@ -20,13 +20,13 @@ class DateTimeExpressionTests: XCTestCase {
 		XCTAssertEqual(sut.generator, .dateTime)
 
 		let attributes = try XCTUnwrap(sut.rules)
-		XCTAssertTrue(attributes.contains { key, _ in
-			key == "format"
-		})
-
-		XCTAssertTrue(attributes.contains(where: { key, _ in
-			key == "expression"
-		}))
+		XCTAssertTrue(
+			["format", "expression"].allSatisfy { keyValue in
+				attributes.contains { key, _ in
+					key == keyValue
+				}
+			}
+		)
 	}
 
 }

--- a/Tests/ExampleGenerators/DateTimeExpressionTests.swift
+++ b/Tests/ExampleGenerators/DateTimeExpressionTests.swift
@@ -13,17 +13,11 @@ import XCTest
 class DateTimeExpressionTests: XCTestCase {
 
 	func testDateTimeExpressionExampleGenerator() throws {
-		let testDate = Date()
 		let testFormat = "dd.MM.yyyy HH:mm:ss"
 		let testExpression = "tomorrow 5pm"
 		let sut = ExampleGenerator.DateTimeExpression(expression: testExpression, format: testFormat)
 
 		XCTAssertEqual(sut.generator, .dateTime)
-
-		let resultValue = try XCTUnwrap(sut.value as? String)
-		let resultDate = try XCTUnwrap(DateHelper.dateFrom(string: resultValue, format: testFormat))
-
-		XCTAssertEqual(testDate.formatted(testFormat), resultDate.formatted(testFormat))
 
 		let attributes = try XCTUnwrap(sut.rules)
 		XCTAssertTrue(attributes.contains { key, _ in

--- a/Tests/ExampleGenerators/DateTimeTests.swift
+++ b/Tests/ExampleGenerators/DateTimeTests.swift
@@ -1,0 +1,36 @@
+//
+//  DateTimeTests.swift
+//  PactSwift
+//
+//  Created by Marko Justinek on 13/2/22.
+//  Copyright © 2022 PACT Foundation. All rights reserved.
+//
+
+import XCTest
+
+@testable import PactSwift
+
+class DateTimeTests: XCTestCase {
+
+	func testDateTimeExampleGenerator() throws {
+		let testDate = Date()
+		let testFormat = "YYYY-MM-DD HH:mm"
+		let sut = ExampleGenerator.DateTime(testDate, format: testFormat)
+
+		XCTAssertEqual(sut.generator, .dateTime)
+
+		let resultValue = try XCTUnwrap(sut.value as? String)
+		let resultDate = try XCTUnwrap(DateHelper.dateFrom(string: resultValue, format: testFormat))
+		// Assert using the same format due to loss of accuracy using a limited datetime format
+		XCTAssertEqual(testDate.formatted(testFormat), resultDate.formatted(testFormat))
+
+		let attributes = try XCTUnwrap(sut.rules)
+		XCTAssertTrue(attributes.contains { key, _ in
+			key == "format"
+		})
+
+		let resultFormat = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
+		XCTAssertEqual(resultFormat.format, testFormat)
+	}
+
+}

--- a/Tests/ExampleGenerators/RandomDateTimeTests.swift
+++ b/Tests/ExampleGenerators/RandomDateTimeTests.swift
@@ -49,4 +49,21 @@ class RandomDateTimeTests: XCTestCase {
 		XCTAssertEqual(result.format, testFormat)
 	}
 
+	func testDateTimeExpression_SetsRules() throws {
+		let testFormat = "yyyy/MM/dd - HH:mm:ss.S"
+		let testExpression = "today +1 day"
+		let testDate = Date()
+		let sut = ExampleGenerator.DateTimeExpression(
+			format: testFormat,
+			expression: testExpression,
+			use: testDate
+		)
+
+		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
+
+		XCTAssertEqual(sut.generator, .dateTime)
+		XCTAssertEqual(result.format, testFormat)
+		XCTAssertEqual(result.expression, testExpression)
+	}
+
 }

--- a/Tests/ExampleGenerators/RandomDateTimeTests.swift
+++ b/Tests/ExampleGenerators/RandomDateTimeTests.swift
@@ -49,21 +49,4 @@ class RandomDateTimeTests: XCTestCase {
 		XCTAssertEqual(result.format, testFormat)
 	}
 
-	func testDateTimeExpression_SetsRules() throws {
-		let testFormat = "yyyy/MM/dd - HH:mm:ss.S"
-		let testExpression = "today +1 day"
-		let testDate = Date()
-		let sut = ExampleGenerator.DateTimeExpression(
-			format: testFormat,
-			expression: testExpression,
-			use: testDate
-		)
-
-		let result = try ExampleGeneratorTestHelpers.encodeDecode(sut.rules!)
-
-		XCTAssertEqual(sut.generator, .dateTime)
-		XCTAssertEqual(result.format, testFormat)
-		XCTAssertEqual(result.expression, testExpression)
-	}
-
 }

--- a/Tests/Extensions/String+PactSwiftTests.swift
+++ b/Tests/Extensions/String+PactSwiftTests.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 7/8/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Tests/Matchers/MatchNullTests.swift
+++ b/Tests/Matchers/MatchNullTests.swift
@@ -3,7 +3,7 @@
 //  PactSwift
 //
 //  Created by Marko Justinek on 9/10/20.
-//  Copyright © 2020 PACT Foundation. All rights reserved.
+//  Copyright © 2020 Marko Justinek. All rights reserved.
 //
 
 import XCTest

--- a/Tests/Model/PactHTTPMethodTests.swift
+++ b/Tests/Model/PactHTTPMethodTests.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 29/8/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Tests/Model/TransferProtocolTests.swift
+++ b/Tests/Model/TransferProtocolTests.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 7/8/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Tests/Services/MockServiceTests.swift
+++ b/Tests/Services/MockServiceTests.swift
@@ -454,7 +454,7 @@ class MockServiceTests: XCTestCase {
 			.willRespondWith(
 				status: 201,
 				body: [
-					"start": ExampleGenerator.DateTimeExpression(format: dateFormat, expression: "@ next hour", use: Date())
+					"start": ExampleGenerator.DateTimeExpression(expression: "@ next hour", format: dateFormat, use: Date())
 				]
 			)
 

--- a/Tests/Services/MockServiceTests.swift
+++ b/Tests/Services/MockServiceTests.swift
@@ -751,6 +751,9 @@ class MockServiceTests: XCTestCase {
 
 	func testMockService_Succeeds_WithGenerators() {
 		let testRegex = #"\d{3}/\d{4,8}"#
+		let testDateTime = Date()
+		let testDateTimeFormat = #"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"#
+		let testResultFormat = #"YYYY-MM-DD HH:mm"#
 
 		mockService
 			.uponReceiving("Request for list of pets")
@@ -769,6 +772,7 @@ class MockServiceTests: XCTestCase {
 					"randomDate": ExampleGenerator.RandomDate(format: "yyyy/MM"),
 					"randomTime": ExampleGenerator.RandomTime(format: "HH:mm - ss"),
 					"randomDateTime": ExampleGenerator.RandomDateTime(format: "HH:mm - dd.MM.yy"),
+					"specificDateTime": ExampleGenerator.DateTime(testDateTime, format: testDateTimeFormat),
 				]
 			)
 
@@ -834,6 +838,12 @@ class MockServiceTests: XCTestCase {
 						let dateTimeRegex = try! NSRegularExpression(pattern: #"\d{2}:\d{2} - \d{2}.\d{2}.\d{2}"#)
 						let dateTimeRange = NSRange(location: 0, length: dateTimeValue.utf16.count)
 						XCTAssertNotNil(dateTimeRegex.firstMatch(in: dateTimeValue, options: [], range: dateTimeRange))
+
+						// Verify specific datetime generator
+						let specificDateTimeValue = try XCTUnwrap(testResult.specificDateTime)
+						let specificDateTimeResult = DateHelper.dateFrom(string: specificDateTimeValue, format: testDateTimeFormat)
+						// Asserting with reduced accuracy of provided format
+						XCTAssertEqual(testDateTime.formatted(testResultFormat), specificDateTimeResult?.formatted(testResultFormat))
 					} catch {
 						XCTFail("Expecting GeneratorsTestModel in \(#function)")
 					}
@@ -958,6 +968,7 @@ private extension MockServiceTests {
 		let randomDate: String
 		let randomTime: String
 		let randomDateTime: String
+		let specificDateTime: String
 	}
 
 	struct EmbeddedMatcherTestModel: Decodable {

--- a/Tests/Services/MockServiceTests.swift
+++ b/Tests/Services/MockServiceTests.swift
@@ -454,7 +454,7 @@ class MockServiceTests: XCTestCase {
 			.willRespondWith(
 				status: 201,
 				body: [
-					"start": ExampleGenerator.DateTimeExpression(expression: "@ next hour", format: dateFormat, use: Date())
+					"start": ExampleGenerator.DateTimeExpression(expression: "@ next hour", format: dateFormat)
 				]
 			)
 

--- a/Tests/Services/PFMockServiceTests.swift
+++ b/Tests/Services/PFMockServiceTests.swift
@@ -1,6 +1,6 @@
 //
 //  Created by Marko Justinek on 31/7/21.
-//  Copyright © 2021 PACT Foundation. All rights reserved.
+//  Copyright © 2021 Marko Justinek. All rights reserved.
 //
 //  Permission to use, copy, modify, and/or distribute this software for any
 //  purpose with or without fee is hereby granted, provided that the above

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -229,7 +229,7 @@ class PactContractTests: XCTestCase {
 				]
 			)
 
-		mockService.run { [self] baseURL, completed in
+		mockService.run { [unowned self] baseURL, completed in
 			let url = URL(string: "\(baseURL)/bugfix")!
 			self.session
 				.dataTask(with: url) { data, response, error in

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -220,8 +220,8 @@ class PactContractTests: XCTestCase {
 								Matcher.IncludesLike("in", "array", generate: "Included in explicit array")
 							],
 							"key_for_datetime_expression": ExampleGenerator.DateTimeExpression(
-								format: "yyyy-MM-dd",
 								expression: "today +1 day",
+								format: "yyyy-MM-dd",
 								use: Date()
 							)
 						]

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -219,11 +219,7 @@ class PactContractTests: XCTestCase {
 								Matcher.RegexLike(value: "2021-05-17", pattern: #"\d{4}-\d{2}-\d{2}"#),
 								Matcher.IncludesLike("in", "array", generate: "Included in explicit array")
 							],
-							"key_for_datetime_expression": ExampleGenerator.DateTimeExpression(
-								expression: "today +1 day",
-								format: "yyyy-MM-dd",
-								use: Date()
-							)
+							"key_for_datetime_expression": ExampleGenerator.DateTimeExpression(expression: "today +1 day", format: "yyyy-MM-dd")
 						]
 					),
 					"array_of_strings": Matcher.EachLike(

--- a/Tests/Services/PactContractTests.swift
+++ b/Tests/Services/PactContractTests.swift
@@ -218,7 +218,12 @@ class PactContractTests: XCTestCase {
 								Matcher.DecimalLike(123.23),
 								Matcher.RegexLike(value: "2021-05-17", pattern: #"\d{4}-\d{2}-\d{2}"#),
 								Matcher.IncludesLike("in", "array", generate: "Included in explicit array")
-							]
+							],
+							"key_for_datetime_expression": ExampleGenerator.DateTimeExpression(
+								format: "yyyy-MM-dd",
+								expression: "today +1 day",
+								use: Date()
+							)
 						]
 					),
 					"array_of_strings": Matcher.EachLike(
@@ -228,15 +233,15 @@ class PactContractTests: XCTestCase {
 				]
 			)
 
-		mockService.run { [unowned self] baseURL, completed in
+		mockService.run { [self] baseURL, completed in
 			let url = URL(string: "\(baseURL)/bugfix")!
-			session
+			self.session
 				.dataTask(with: url) { data, response, error in
 					guard
 						error == nil,
 						(response as? HTTPURLResponse)?.statusCode == 200
 					else {
-						fail(function: #function, request: url.absoluteString, response: response.debugDescription, error: error)
+						self.fail(function: #function, request: url.absoluteString, response: response.debugDescription, error: error)
 						return
 					}
 					// We don't care about the network response here, so we tell PactSwift we're done with the Pact test

--- a/Tests/TestHelpers/DateHelper.swift
+++ b/Tests/TestHelpers/DateHelper.swift
@@ -31,4 +31,10 @@ enum DateHelper {
 		return formatter.date(from: string)
 	}
 
+	static func stringFrom(date: Date, format: String) -> String {
+		let formatter = DateFormatter()
+		formatter.dateFormat = format
+		return formatter.string(from: date)
+	}
+
 }


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Adds a new `DateTimeExpression` example generator that handles date time expressions  
(pact-foundation/pact-reference/issues/180)
- Refactors `DateTime` example generator
- Fixes the env var's value for logging
- Refactors `Date` helpers
- Fixes copyright headers

## 💁 Example

```swift
.willRespondWith(
    status: 201,
    body: [
        "start": ExampleGenerator.DateTimeExpression(expression: "@ next hour", format: dateFormat)
    ]
)
```

## 📝 Notes

- PactSwift uses `pact-rust` as the core. When creating the Pact structure that's being passed to the rust core, the actual date value is irrelevant because rust core re-generates it based on the given expression. I've reached out to `pact-rust` team about thoughts on passing an optional reference date.

## 🔨 How To Test

Unit tests have been written. 
Create a project where an `ExampleGenerator.DateTimeExpression(format: expression: use:)` is defined in a request's or response's body.
Run the test and verify the written Pact file contains the datetime generator with an expression. 