### PR TITLE
Make the `done` function Sendable

### DIFF
--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		55E8E3522936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */; };
+		55E8E3532936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */; };
 		AD07404027F93BC1000C498C /* EachKeyLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */; };
 		AD07404127F93BC1000C498C /* EachKeyLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */; };
 		AD07404327F93BD5000C498C /* EachKeyLike.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07404227F93BD5000C498C /* EachKeyLike.swift */; };
@@ -255,6 +257,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncMockServiceTests.swift; sourceTree = "<group>"; };
 		AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKeyLikeTests.swift; sourceTree = "<group>"; };
 		AD07404227F93BD5000C498C /* EachKeyLike.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKeyLike.swift; sourceTree = "<group>"; };
 		AD08FA3D28A23DD40059884F /* PactFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactFileManager.swift; sourceTree = "<group>"; };
@@ -507,6 +510,7 @@
 				AD78FB47264FD21900765BD3 /* PactContractTests.swift */,
 				AD92805026BE1B60004FAA7E /* PFMockServiceTests.swift */,
 				ADBC3E5B26DB4846006908E0 /* ProviderVerifierTests.swift */,
+				55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1150,6 +1154,7 @@
 				ADBC3E5626DB36A8006908E0 /* WIPPactsTests.swift in Sources */,
 				ADD0317B2512439500C6099B /* RandomIntTests.swift in Sources */,
 				ADEDDF092547CFC200A45AD2 /* ObjCMatcherTests.swift in Sources */,
+				55E8E3522936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */,
 				ADEDDF1B2547DF3200A45AD2 /* ToolboxTests.swift in Sources */,
 				AD7891BA2441512E0014BCC8 /* SomethingLikeTests.swift in Sources */,
 				AD54436127D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */,
@@ -1275,6 +1280,7 @@
 				ADBC3E5726DB36A8006908E0 /* WIPPactsTests.swift in Sources */,
 				ADD0317C2512439500C6099B /* RandomIntTests.swift in Sources */,
 				ADEDDF0A2547CFC200A45AD2 /* ObjCMatcherTests.swift in Sources */,
+				55E8E3532936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */,
 				ADEDDF1C2547DF3200A45AD2 /* ToolboxTests.swift in Sources */,
 				AD8FC80A2463BBD100361854 /* ErrorCapture.swift in Sources */,
 				AD54436227D3316600D4C464 /* DateTimeExpressionTests.swift in Sources */,

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -138,7 +138,7 @@ open class MockService {
 	/// }
 	/// ```
 	///
-	public func run(_ file: FileString? = #file, line: UInt? = #line, verify interactions: [Interaction]? = nil, timeout: TimeInterval? = nil, testFunction: @escaping (_ baseURL: String, _ done: (@escaping () -> Void)) throws -> Void) {
+	public func run(_ file: FileString? = #file, line: UInt? = #line, verify interactions: [Interaction]? = nil, timeout: TimeInterval? = nil, testFunction: @escaping (_ baseURL: String, _ done: (@Sendable @escaping () -> Void)) throws -> Void) {
 		// Use the provided set or if not provided only the current interaction
 		pact.interactions = interactions ?? [currentInteraction]
 
@@ -238,7 +238,7 @@ extension MockService {
 
 private extension MockService {
 
-	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: (String, @escaping (() -> Void)) throws -> Void) {
+	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: (String, @escaping (@Sendable () -> Void)) throws -> Void) {
 		waitForPactTestWith(timeout: timeout, file: file, line: line) { [unowned self] completion in
 			Logger.log(message: "Setting up pact test", data: pact.data)
 

--- a/Tests/Services/AsyncMockServiceTests.swift
+++ b/Tests/Services/AsyncMockServiceTests.swift
@@ -1,0 +1,73 @@
+//
+//  Created by Huw Rowlands on 30/11/2022.
+//  Copyright © 2022 Huw Rowlands. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+import XCTest
+
+@testable import PactSwift
+
+import Foundation
+
+// FoundationNetworking for Linux does not seem to support the async `URLSession.data(from:)` methods.
+#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
+final class MockServiceAsyncTests: XCTestCase {
+
+	var mockService: MockService!
+	var errorCapture: ErrorCapture!
+
+	private var secureProtocol: Bool = false
+
+	// MARK: - Lifecycle
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+
+		guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+			throw XCTSkip("Unsupported OS")
+		}
+
+		errorCapture = ErrorCapture()
+		mockService = MockService(consumer: "pactswift-unit-tests", provider: "unit-test-api-provider", errorReporter: errorCapture)
+	}
+
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func testMockService_SimpleGetRequest_InsideTask() {
+		mockService
+			.uponReceiving("Request for a list")
+			.given("elements exist")
+			.withRequest(method: .GET, path: "/elements")
+			.willRespondWith(status: 200)
+
+		let testExpectation = expectation(description: #function)
+
+		mockService.run(timeout: 1) { baseURL, completion in
+			let session = URLSession.shared
+			Task {
+				let (_, response) = try await session.data(from: URL(string: "\(baseURL)/elements")!)
+
+				if let response = response as? HTTPURLResponse {
+					XCTAssertEqual(200, response.statusCode)
+					completion()
+					testExpectation.fulfill()
+				} else {
+					XCTFail("Expecting response code 200 in \(#function)")
+				}
+			}
+		}
+		waitForExpectations(timeout: 1)
+	}
+
+}
+#endif


### PR DESCRIPTION
Tasks are created with a Sendable closure. Therefore, whatever they capture must also be Sendable.

We should make the `done` function Sendable. If it's Sendable, we can use it inside Sendable closures. That way, `done` can be captured by a Task.

For example, if you were verifying an API client inside a Task, you would need to call the `done` function inside of that Task. Anything the Task captures must be Sendable.

Fortunately, since `done` takes no parameters, making `done` Sendable is a relatively straightforward process.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Make the `done` function `Sendable`.

# 🧐🗒 Reviewer Notes

## 💁 Example

For example, when verifying your API Client:

```swift
PassingTestsExample.mockService.run(timeout: 1) { [unowned self] mockServiceURL, done in
  apiClient.baseUrl = mockServiceURL

  // ✏️ Making the API request inside of a Task
  Task {
    let users = await apiClient.getUsers()
    XCTAssertEqual(users.count, 20)
    XCTAssertEqual(users.first?.firstName, "John")
    XCTAssertEqual(users.first?.lastName, "Tester")

    // ✏️ The `done` function must be called inside the Task so that it's called after the apiClient returns
    // ⚠️ Before this change, this would emit a warning.
    done()
  }
}
```
