### PR TITLE
Better support for Swift Structured Concurrency

### DIFF
--- a/PactSwift.xcodeproj/project.pbxproj
+++ b/PactSwift.xcodeproj/project.pbxproj
@@ -9,6 +9,10 @@
 /* Begin PBXBuildFile section */
 		55E8E3522936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */; };
 		55E8E3532936F3AD003D57A6 /* AsyncMockServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */; };
+		A782763E29372E35003809F9 /* MockServer+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A782763D29372E35003809F9 /* MockServer+Async.swift */; };
+		A782763F29372E35003809F9 /* MockServer+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = A782763D29372E35003809F9 /* MockServer+Async.swift */; };
+		A7AF63D029387BE900A7FD42 /* Task+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AF63CF29387BE900A7FD42 /* Task+Timeout.swift */; };
+		A7AF63D129387BE900A7FD42 /* Task+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AF63CF29387BE900A7FD42 /* Task+Timeout.swift */; };
 		AD07404027F93BC1000C498C /* EachKeyLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */; };
 		AD07404127F93BC1000C498C /* EachKeyLikeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */; };
 		AD07404327F93BD5000C498C /* EachKeyLike.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD07404227F93BD5000C498C /* EachKeyLike.swift */; };
@@ -258,6 +262,8 @@
 
 /* Begin PBXFileReference section */
 		55E8E3512936F3AD003D57A6 /* AsyncMockServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncMockServiceTests.swift; sourceTree = "<group>"; };
+		A782763D29372E35003809F9 /* MockServer+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MockServer+Async.swift"; sourceTree = "<group>"; };
+		A7AF63CF29387BE900A7FD42 /* Task+Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Task+Timeout.swift"; sourceTree = "<group>"; };
 		AD07403F27F93BC1000C498C /* EachKeyLikeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKeyLikeTests.swift; sourceTree = "<group>"; };
 		AD07404227F93BD5000C498C /* EachKeyLike.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EachKeyLike.swift; sourceTree = "<group>"; };
 		AD08FA3D28A23DD40059884F /* PactFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PactFileManager.swift; sourceTree = "<group>"; };
@@ -599,6 +605,8 @@
 				ADC372B3269877AF000DA90B /* Sequence+PactSwift.swift */,
 				ADEDDEFC2547B6FA00A45AD2 /* String+PactSwift.swift */,
 				ADD03174251235A800C6099B /* UUID+PactSwift.swift */,
+				A782763D29372E35003809F9 /* MockServer+Async.swift */,
+				A7AF63CF29387BE900A7FD42 /* Task+Timeout.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1100,6 +1108,7 @@
 				ADA17E3B25137716004F1A82 /* RandomDateTime.swift in Sources */,
 				ADE9B3C7250A3C4700274672 /* Matcher.swift in Sources */,
 				ADD031782512425800C6099B /* RandomInt.swift in Sources */,
+				A782763E29372E35003809F9 /* MockServer+Async.swift in Sources */,
 				AD72E54027B89CB900C7453F /* DateTime.swift in Sources */,
 				AD9D7D8D26C8AD3400FE4137 /* ProviderStateGenerator.swift in Sources */,
 				ADD3C27624416DAE002E73B9 /* IncludesLike.swift in Sources */,
@@ -1111,6 +1120,7 @@
 				ADEFD134253EEF230081A1B1 /* Toolbox.swift in Sources */,
 				AD641A3A24344D9500785CE1 /* Pact.swift in Sources */,
 				ADA40177253028A100265DF3 /* MatchNull.swift in Sources */,
+				A7AF63D029387BE900A7FD42 /* Task+Timeout.swift in Sources */,
 				AD10361424468AB3002C97CA /* MockService.swift in Sources */,
 				ADA17E5225138908004F1A82 /* RandomDecimal.swift in Sources */,
 				ADD03167251220FD00C6099B /* RandomBool.swift in Sources */,
@@ -1226,6 +1236,7 @@
 				ADA17E3C25137716004F1A82 /* RandomDateTime.swift in Sources */,
 				ADE9B3C8250A3C4700274672 /* Matcher.swift in Sources */,
 				ADD031792512425800C6099B /* RandomInt.swift in Sources */,
+				A782763F29372E35003809F9 /* MockServer+Async.swift in Sources */,
 				AD72E54127B89CB900C7453F /* DateTime.swift in Sources */,
 				AD9D7D8E26C8AD3400FE4137 /* ProviderStateGenerator.swift in Sources */,
 				AD8FC7E82463BB9F00361854 /* PactHTTPMethod.swift in Sources */,
@@ -1237,6 +1248,7 @@
 				ADEFD135253EEF230081A1B1 /* Toolbox.swift in Sources */,
 				ADA40178253028A100265DF3 /* MatchNull.swift in Sources */,
 				AD8FC7F82463BBB800361854 /* RegexLike.swift in Sources */,
+				A7AF63D129387BE900A7FD42 /* Task+Timeout.swift in Sources */,
 				AD8FC7F32463BBB800361854 /* EachLike.swift in Sources */,
 				ADA17E5325138908004F1A82 /* RandomDecimal.swift in Sources */,
 				ADD03168251220FD00C6099B /* RandomBool.swift in Sources */,

--- a/Sources/Extensions/MockServer+Async.swift
+++ b/Sources/Extensions/MockServer+Async.swift
@@ -15,15 +15,10 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
-import Foundation
+#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
 
-#if os(Linux)
-import PactSwiftMockServerLinux
-#elseif compiler(>=5.5)
+import Foundation
 @_implementationOnly import PactSwiftMockServer
-#else
-import PactSwiftMockServer
-#endif
 
 extension MockServer {
 	
@@ -73,3 +68,5 @@ extension MockServer {
 	}
 
 }
+
+#endif

--- a/Sources/Extensions/MockServer+Async.swift
+++ b/Sources/Extensions/MockServer+Async.swift
@@ -1,0 +1,75 @@
+//
+//  Created by Oliver Jones on 30/11/2022.
+//  Copyright © 2022 Oliver Jones. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+
+#if os(Linux)
+import PactSwiftMockServerLinux
+#elseif compiler(>=5.5)
+@_implementationOnly import PactSwiftMockServer
+#else
+import PactSwiftMockServer
+#endif
+
+extension MockServer {
+	
+	/// Spins up a mock server with expected interactions defined in the provided Pact
+	///
+	/// - Parameters:
+	///   - pact: The pact contract
+	///   - protocol: HTTP protocol
+	///
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	@discardableResult
+	func setup(pact: Data, protocol: PactSwiftMockServer.TransferProtocol = .standard) async throws -> Int {
+		try await withCheckedThrowingContinuation { continuation in
+			self.setup(pact: pact, protocol: `protocol`) { result in
+				continuation.resume(with: result)
+			}
+		}
+	}
+	
+	/// Verifies all interactions passed to mock server
+	///
+	/// By default pact files are written to `/tmp/pacts`.
+	/// Use `PACT_OUTPUT_DIR` environment variable with absolute path to your custom path in schema `run` configuration.
+	///
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func verify() async throws -> Bool {
+		try await withCheckedThrowingContinuation { continuation in
+			self.verify { result in
+				continuation.resume(with: result)
+			}
+		}
+	}
+	
+	/// Finalises Pact tests by writing the pact contract file to disk
+	///
+	/// - Parameters:
+	///   - pact: The Pact contract to write
+	///   - completion: A completion block called when setup completes
+	///
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func finalize(pact: Data) async throws -> String {
+		try await withCheckedThrowingContinuation { continuation in
+			self.finalize(pact: pact) { result in
+				continuation.resume(with: result)
+			}
+		}
+	}
+
+}

--- a/Sources/Extensions/Task+Timeout.swift
+++ b/Sources/Extensions/Task+Timeout.swift
@@ -15,6 +15,8 @@
 //  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 //
 
+#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
+
 import Foundation
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
@@ -45,3 +47,5 @@ struct TimeoutError: LocalizedError {
 	var interval: TimeInterval
 	var errorDescription: String? { "Task timed out after \(interval) seconds" }
 }
+
+#endif

--- a/Sources/Extensions/Task+Timeout.swift
+++ b/Sources/Extensions/Task+Timeout.swift
@@ -1,0 +1,47 @@
+//
+//  Created by Oliver Jones on 1/12/2022.
+//  Copyright © 2022 Oliver Jones. All rights reserved.
+//
+//  Permission to use, copy, modify, and/or distribute this software for any
+//  purpose with or without fee is hereby granted, provided that the above
+//  copyright notice and this permission notice appear in all copies.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//  SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//  IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+//
+
+import Foundation
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension Task where Failure == Error {
+	
+	// Start a new Task with a timeout. If the timeout expires before the operation is
+	// completed then the task is cancelled and an error is thrown.
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	init(priority: TaskPriority? = nil, timeout: TimeInterval, operation: @escaping @Sendable () async throws -> Success) {
+		self = Task(priority: priority) {
+			try await withThrowingTaskGroup(of: Success.self) { group -> Success in
+				group.addTask(operation: operation)
+				group.addTask {
+					try await _Concurrency.Task.sleep(nanoseconds: UInt64(timeout * Double(NSEC_PER_SEC)))
+					throw TimeoutError(interval: timeout)
+				}
+				guard let success = try await group.next() else {
+					throw _Concurrency.CancellationError()
+				}
+				group.cancelAll()
+				return success
+			}
+		}
+	}
+}
+
+struct TimeoutError: LocalizedError {
+	var interval: TimeInterval
+	var errorDescription: String? { "Task timed out after \(interval) seconds" }
+}

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -125,7 +125,7 @@ open class MockService {
 	///   - timeout: Time before the test times out. Default is 10 seconds
 	///   - testFunction: Your code making the API request
 	///
-	/// The `testFunction` completion block passes two values to your unit test. A `String` representing
+	/// The `testFunction` block passes two values to your unit test. A `String` representing
 	/// the url of the active Mock Server and a `Void` function that you call when you are done with your unit test.
 	/// You must call this function within your `testFunction:` completion block when your test completes. It signals PactSwift
 	/// that your test finished. If you do not call it then your test will time out.
@@ -138,20 +138,11 @@ open class MockService {
 	/// }
 	/// ```
 	///
-	public func run(_ file: FileString? = #file, line: UInt? = #line, verify interactions: [Interaction]? = nil, timeout: TimeInterval? = nil, testFunction: @escaping (_ baseURL: String, _ done: (@Sendable @escaping () -> Void)) throws -> Void) {
+	public func run(_ file: FileString? = #file, line: UInt? = #line, verify interactions: [Interaction]? = nil, timeout: TimeInterval? = nil, testFunction: @escaping (_ baseURL: String, _ done: (@escaping @Sendable () -> Void)) throws -> Void) {
 		// Use the provided set or if not provided only the current interaction
 		pact.interactions = interactions ?? [currentInteraction]
 
-		// Check there are no invalid interactions
-		var hasErrors = false
-		pact.interactions.forEach { interaction in
-			interaction.encodingErrors.forEach {
-				hasErrors = true
-				failWith($0.localizedDescription, file: file, line: line)
-			}
-		}
-
-		if hasErrors {
+		if checkForInvalidInteractions(pact.interactions, file: file, line: line) {
 			// Remove interactions with errors
 			pact.interactions.removeAll { $0.encodingErrors.isEmpty == false }
 			self.interactions.removeAll()
@@ -166,7 +157,56 @@ open class MockService {
 			verifyPactInteraction(timeout: timeout ?? Constants.kTimeout, file: file, line: line, mockServer: mockServer)
 		}
 	}
+		
+	/// Runs the Pact test against the code making the API request
+	///
+	/// - Parameters:
+	///   - file: The file to report the failing test in
+	///   - line: The line on which to report the failing test
+	///   - verify: An array of specific `Interaction`s to verify. If none provided, the latest defined interaction is used
+	///   - timeout: Time before the test times out. Default is 10 seconds
+	///   - testFunction: Your async code making the API request
+	///
+	/// The `testFunction` closure is passed a `String` representing  the url of the active Mock Server.
+	///
+	/// ```
+	/// try await mockService.run { baseURL in
+	///   // async code making the request with provided `baseURL`
+	///   // assert response can be processed
+	/// }
+	/// ```
+	///
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	public func run(_ file: FileString? = #file, line: UInt? = #line, verify interactions: [Interaction]? = nil, timeout: TimeInterval? = nil, testFunction: @escaping @Sendable (_ baseURL: String) async throws -> Void) async throws {
+		// Use the provided set or if not provided only the current interaction
+		pact.interactions = interactions ?? [currentInteraction]
 
+		if checkForInvalidInteractions(pact.interactions, file: file, line: line) {
+			// Remove interactions with errors
+			pact.interactions.removeAll { $0.encodingErrors.isEmpty == false }
+			self.interactions.removeAll()
+		} else {
+			// Prepare a brand spanking new MockServer (Mock Provider) on its own port
+			let mockServer = MockServer()
+
+			// Set the expectations so we don't wait for this async magic indefinitely
+			try await setupPactInteraction(timeout: timeout ?? Constants.kTimeout, file: file, line: line, mockServer: mockServer, testFunction: testFunction)
+
+			// At the same time start listening to verification that Mock Server received the expected request
+			try await verifyPactInteraction(timeout: timeout ?? Constants.kTimeout, file: file, line: line, mockServer: mockServer)
+		}
+	}
+
+
+	/// Check there are no invalid interactions
+	private func checkForInvalidInteractions(_ interactions: [Interaction], file: FileString? = nil, line: UInt? = nil) -> Bool {
+		let errors = interactions.flatMap(\.encodingErrors)
+		for error in errors {
+			failWith(error.localizedDescription, file: file, line: line)
+		}
+				
+		return errors.isEmpty == false
+	}
 }
 
 // MARK: - Internal
@@ -202,6 +242,33 @@ extension MockService {
 				failWith(error.description)
 				completion?(.failure(error))
 			}
+		}
+	}
+	
+	/// Writes a Pact contract file in JSON format
+	///
+	/// By default Pact contracts are written to `/tmp/pacts` folder.
+	/// Set `PACT_OUTPUT_DIR` to `$(PATH)/to/desired/dir/` in `Build` phase of your `Scheme` to change the location.
+	///
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func finalize(file: FileString? = nil, line: UInt? = nil) async throws -> String {
+		// Spin up a fresh Mock Server with a directory to write to
+		let mockServer = MockServer(directory: pactsDirectory, merge: self.merge)
+
+		// Gather all the interactions this MockService has received to set up and prepare Pact data with them all
+		pact.interactions = interactions.filter { $0.encodingErrors.isEmpty }
+
+		// Validate the Pact `Data` is hunky dory
+		guard let pactData = pact.data else {
+			throw MockServerError.nullPointer
+		}
+
+		// Ask Mock Server to do the actual Pact file writing to disk
+		do {
+			return try await mockServer.finalize(pact: pactData)
+		} catch {
+			failWith((error as? MockServerError)?.description ?? error.localizedDescription, file: file, line: line)
+			throw error
 		}
 	}
 
@@ -264,6 +331,56 @@ private extension MockService {
 		}
 	}
 
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: @escaping (String) async throws -> Void) async throws {
+		Logger.log(message: "Setting up pact test", data: pact.data)
+		do {
+			// Set up a Mock Server with Pact data and on desired http protocol
+			try await mockServer.setup(pact: pact.data!, protocol: transferProtocolScheme)
+			
+			// If Mock Server spun up, run the test function
+			let task = Task(timeout: timeout) {
+				do {
+					try await testFunction(mockServer.baseUrl)
+				} catch {
+					self.failWith("🚨 Error thrown in test function: \(error.localizedDescription)", file: file, line: line)
+					throw error
+				}
+			}
+			// await task completion (value is Void)
+			try await task.value
+		} catch {
+			// Failed to spin up a Mock Server. This could be due to bad Pact data. Most likely to Pact data.
+			failWith((error as? MockServerError)?.description ?? error.localizedDescription, file: file, line: line)
+			throw error
+		}
+	}
+	
+	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+	func verifyPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer) async throws {
+		do {
+			let task = Task(timeout: timeout) {
+				try await mockServer.verify()
+			}
+			// await task completion (value is discarded)
+			_ = try await task.value
+			
+			// If the comsumer (in testFunction:) made the promised request to Mock Server, go and finalize the test.
+			// Only finalize when running in simulator, maOS or Linux. Running on a physical iOS device makes little sense due to
+			// writing a pact file to device's disk. `libpact_ffi` does the actual file writing it writes it onto the
+			// disk of the device it is being run on.
+			#if targetEnvironment(simulator) || os(macOS) || os(Linux)
+			let message = try await finalize(file: file, line: line)
+			Logger.log(message: message, data: self.pact.data)
+			#else
+			print("[INFO]: Running on an iOS device. Writing Pact interaction into a contract skipped.")
+			#endif
+		} catch {
+			failWith((error as? MockServerError)?.description ?? error.localizedDescription, file: file, line: line)
+			throw error
+		}
+	}
+	
 	func verifyPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer) {
 		waitForPactTestWith(timeout: timeout, file: file, line: line) { [unowned self] completion in
 			// Ask Mock Server to verify the promised request (testFunction:) has been made

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -344,12 +344,7 @@ private extension MockService {
 			
 			// If Mock Server spun up, run the test function
 			let task = Task(timeout: timeout) {
-				do {
-					try await testFunction(mockServer.baseUrl)
-				} catch {
-					self.failWith("🚨 Error thrown in test function: \(error.localizedDescription)", file: file, line: line)
-					throw error
-				}
+				try await testFunction(mockServer.baseUrl)
 			}
 			// await task completion (value is Void)
 			try await task.value

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -157,7 +157,8 @@ open class MockService {
 			verifyPactInteraction(timeout: timeout ?? Constants.kTimeout, file: file, line: line, mockServer: mockServer)
 		}
 	}
-		
+
+	#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
 	/// Runs the Pact test against the code making the API request
 	///
 	/// - Parameters:
@@ -196,7 +197,8 @@ open class MockService {
 			try await verifyPactInteraction(timeout: timeout ?? Constants.kTimeout, file: file, line: line, mockServer: mockServer)
 		}
 	}
-
+	#endif
+	
 	/// Check there are no invalid interactions
 	private func checkForInvalidInteractions(_ interactions: [Interaction], file: FileString? = nil, line: UInt? = nil) -> Bool {
 		let errors = interactions.flatMap(\.encodingErrors)
@@ -244,6 +246,7 @@ extension MockService {
 		}
 	}
 	
+	#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
 	/// Writes a Pact contract file in JSON format
 	///
 	/// By default Pact contracts are written to `/tmp/pacts` folder.
@@ -270,6 +273,7 @@ extension MockService {
 			throw error
 		}
 	}
+	#endif
 
 	/// Waits for test to be completed and fails if timed out
 	func waitForPactTestWith(timeout: TimeInterval, file: FileString?, line: UInt?, action: (@escaping () -> Void) -> Void) {
@@ -329,7 +333,8 @@ private extension MockService {
 			}
 		}
 	}
-
+	
+	#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
 	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: @escaping (String) async throws -> Void) async throws {
 		Logger.log(message: "Setting up pact test", data: pact.data)
@@ -379,6 +384,7 @@ private extension MockService {
 			throw error
 		}
 	}
+	#endif
 	
 	func verifyPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer) {
 		waitForPactTestWith(timeout: timeout, file: file, line: line) { [unowned self] completion in

--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -197,7 +197,6 @@ open class MockService {
 		}
 	}
 
-
 	/// Check there are no invalid interactions
 	private func checkForInvalidInteractions(_ interactions: [Interaction], file: FileString? = nil, line: UInt? = nil) -> Bool {
 		let errors = interactions.flatMap(\.encodingErrors)


### PR DESCRIPTION
# 📝 Summary of Changes

Changes proposed in this pull request:

- Introduces wrappers on MockServer to make it compatible with `await`.
- Adds a `Task` initialiser and `TimeoutError` that allows for task timeout.
- Adds `run(...) async throws` on MockService for use in `async throws` tests so you can easily test API clients that use Swift Structured Concurrency.

# ⚠️ Items of Note

I've marked all these APIs as only available in iOS 15+ and macOS 12+ even though technically many of the APIs are supported from iOS 13.  I feel like iOS 15 was the first version where they were not buggy. YMMV.

# 🧐🗒 Reviewer Notes

## 🔨 How To Test

There is an included unit test.