### PR TITLE
Add macOS 12 test runner

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -10,19 +10,21 @@ env:
 
 jobs:
   test:
-    name: Run on macOS 11
-    runs-on: macos-11
+    name: Run ${{ matrix.platform }} on ${{ matrix.host }}
+    runs-on: ${{ matrix.host }}
 
     strategy:
       fail-fast: true
       matrix:
+        host: [macos-11, macos-12]
+        platform: [ios, macos]
         include:
-          - scheme: "PactSwift-iOS"
+          - platform: ios
+            scheme: "PactSwift-iOS"
             destination: "platform=iOS Simulator,name=iPhone 12 Pro"
-          - scheme: "PactSwift-macOS"
+          - platform: macos
+            scheme: "PactSwift-macOS"
             destination: "arch=x86_64"
-          # - scheme: "PactSwift-macOS"
-          #   destination: "arch=arm64"
 
     env:
       SCHEME: ${{ matrix.scheme }}


### PR DESCRIPTION
# 📝 Summary of Changes

Previously, we only ran the macOS tests on macOS 11. Let’s try adding macOS 12 as well.

# ⚠️ Items of Note

We've used [Job Matrices](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs) to give us the combination of host OS (macOS 11 and 12) and platform (iOS and macOS). We could add macOS 13 one day too.

This only does PRs. It does not do `build.yml`.
