### PR TITLE
Make Build run against macOS 12 as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,25 @@ env:
 
 jobs:
   test:
-    name: Run on macOS 11
-    runs-on: macos-11
-
+    name: Run ${{ matrix.platform }} on ${{ matrix.host }}
+    runs-on: ${{ matrix.host }}
+  
     strategy:
       fail-fast: true
       matrix:
+        host: [macos-11, macos-12]
+        platform: [ios, macos]
         include:
-          - scheme: "PactSwift-iOS"
+          - platform: ios
+            scheme: "PactSwift-iOS"
             destination: "platform=iOS Simulator,name=iPhone 12 Pro"
-          - scheme: "PactSwift-macOS"
+          - platform: macos
+            scheme: "PactSwift-macOS"
             destination: "arch=x86_64"
+          - host: macos-11
+            xcode: 13.2.1
+          - host: macos-12
+            xcode: 14.0.1
 
     env:
       SCHEME: ${{ matrix.scheme }}
@@ -44,8 +52,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Use Xcode 13.2.1
-        run: sudo xcode-select -switch /Applications/Xcode_13.2.1.app
+      - name: Use Xcode ${{ matrix.xcode }}
+        run: sudo xcode-select -switch /Applications/Xcode_${{ matrix.xcode }}.app
 
       - name: Prepare Tools
         run: |


### PR DESCRIPTION
# 📝 Summary of Changes

In my [previous PR](https://github.com/surpher/PactSwift/pull/99), I had made the PR builds run against macOS 12. That was fine, but there are actually two workflows: one for PR builds, and one for the main branch. 

This PR updates the main branch to run against macOS 12 as well as macOS 11. It is more explicit about what Xcode version to use on each agent (as per @surpher's preference)

## 🔨 How To Test

Just wait :) Hope they pass.