### PR TITLE
Use `host` in concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
       DESTINATION: ${{ matrix.destination }}
 
     concurrency:
-      group: test-${{ matrix.scheme }}-${{ github.ref }}
+      group: test_${{ matrix.host }}_${{ matrix.scheme }}_${{ github.ref }}
       cancel-in-progress: true
 
     steps:


### PR DESCRIPTION
# 📝 Summary of Changes

Previously, we had two jobs running with the macOS scheme. The `concurrency.group` could not differentiate them and therefore cancelled one.

We can add the host to the `group` so it knows not to do that.

See more: https://docs.github.com/en/actions/using-jobs/using-concurrency

## 🔨 How To Test

Wait :)