### PR TITLE
Mark testFunction as Sendable in setup

### DIFF
--- a/Sources/MockService.swift
+++ b/Sources/MockService.swift
@@ -336,12 +336,12 @@ private extension MockService {
 	
 	#if canImport(_Concurrency) && compiler(>=5.7) && !os(Linux)
 	@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: @escaping (String) async throws -> Void) async throws {
+	func setupPactInteraction(timeout: TimeInterval, file: FileString?, line: UInt?, mockServer: MockServer, testFunction: @escaping @Sendable (String) async throws -> Void) async throws {
 		Logger.log(message: "Setting up pact test", data: pact.data)
 		do {
 			// Set up a Mock Server with Pact data and on desired http protocol
 			try await mockServer.setup(pact: pact.data!, protocol: transferProtocolScheme)
-			
+
 			// If Mock Server spun up, run the test function
 			let task = Task(timeout: timeout) {
 				try await testFunction(mockServer.baseUrl)


### PR DESCRIPTION
The `testFunction` collected from the async `run` function is marked as [`Sendable`](https://developer.apple.com/documentation/swift/sendable). That imposes certain restrictions, such as disallowing the capture of non-Sendable values inside the `testFunction`.

The annotation was not extended to Pact’s internal functions, however. The `setupPactInteraction` function passes it to a `Task`, and the `Task`’s operation is Sendable. Closures implicitly get Sendable conformance in contexts like that, but I think it's preferable to be explicit in this case.

# 📝 Summary of Changes

Changes proposed in this pull request:

- Add `@Sendable` annotation to internal `setupPactInteraction` func.

# 🧐🗒 Reviewer Notes

This is a minor correction.