### PR TITLE
Skip SwiftLint when building via Carthage

### DIFF
--- a/Scripts/build_file_list_and_swiftlint
+++ b/Scripts/build_file_list_and_swiftlint
@@ -19,6 +19,12 @@
 
 set -eu
 
+if [ "${CARTHAGE:-}" = "YES" ]; then
+  echo "--- Skipping SwiftLint for Carthage build"
+  touch "${DERIVED_FILE_DIR:-.}/swiftlint.txt"
+  exit 0
+fi
+
 # Adds support for Apple Silicon brew directory
 export PATH="$PATH:/opt/homebrew/bin"
 


### PR DESCRIPTION
# 📝 Summary of Changes
	•	Skip running SwiftLint when CARTHAGE=YES to prevent SourceKitten/sourcekitd crashes during Carthage builds on newer Xcode toolchains.
	•	Keep SwiftLint running for normal Xcode builds.

Items of Note
	•	This only changes behavior for Carthage builds.
	•	When skipping, the script still creates the expected swiftlint.txt output so the build phase remains satisfied.

## 🔨 How To Test

_Provide instructions on how to test your changes._
	1.	Integrate this branch/commit via Cartfile:
github "osamaghaffar/PactSwift" "carthage-skip-swiftlint"
	2.	Run:
carthage bootstrap --platform iOS --cache-builds --verbose
	3.	Confirm build completes and SwiftLint is skipped when CARTHAGE=YES.
