### PR TITLE
fix: make XCTest import conditional

### DIFF
--- a/Sources/Model/ErrorReporter.swift
+++ b/Sources/Model/ErrorReporter.swift
@@ -16,6 +16,8 @@
 //
 
 import Foundation
+
+#if canImport(XCTest)
 import XCTest
 
 class ErrorReporter: ErrorReportable {
@@ -31,3 +33,21 @@ class ErrorReporter: ErrorReportable {
 	}
 
 }
+
+#else
+
+class ErrorReporter: ErrorReportable {
+
+	/// Reports test failure in file and on line where this method is called
+	func reportFailure(_ message: String) {
+		preconditionFailure(message)
+	}
+
+	/// Reports test failure in provided file and on provided line
+	func reportFailure(_ message: String, file: FileString, line: UInt) {
+		preconditionFailure("\(file):\(line): \(message)")
+	}
+
+}
+
+#endif

--- a/Sources/ProviderVerifier.swift
+++ b/Sources/ProviderVerifier.swift
@@ -16,7 +16,6 @@
 //
 
 import Foundation
-import XCTest
 
 import PactSwiftMockServer
 


### PR DESCRIPTION
## 📝 Summary of Changes

Wrap `import XCTest` in `ErrorReporter.swift` with `#if canImport(XCTest)` so PactSwift compiles with the standalone Swift toolchain (e.g. mise-managed swift.org builds) where XCTest is not available without Xcode's SDK.

- On Apple platforms with Xcode: XCTest path unchanged, `XCTFail` used as before.
- Without XCTest (standalone toolchain, Linux): `preconditionFailure` fallback.

`ProviderVerifier.swift` had a superfluous `import XCTest` that was unused at the call site (all XCTest usage is in `ErrorReporter`) — removed.

## ⚠️ Items of Note

## 🧐🗒 Reviewer Notes

I ran into this issue while trying to code up an example using the v2 feature branch, trying to run it against Swift 6 managed by [mise](https://mise.jdx.dev/) to try and have a cross-platform example, using the [Swift Testing](https://developer.apple.com/xcode/swift-testing/) framework.

I will be honest, I am _not_ an expert with Swift, and the changes in this PR were suggested by an LLM; however, I this did resolve the issue with the example and the change itself does seem quite sensible.

## 💁 Example

The examples repo is not yet public, but I fully intend to make it public once it has been through a couple of rounds of review. I'll let you know!

## 🔨 How To Test

This is where my Swift knowledge fails me 😅 I have tested this change using a locally patched package with a full example, but I'm not sure how best to add test coverage for this specifically within this repo. Feel free to point me in the right direction if you need me to add some unit tests specifically for this.